### PR TITLE
52 iolanta browse foaf is super slow

### DIFF
--- a/iolanta/cyberspace/processor.py
+++ b/iolanta/cyberspace/processor.py
@@ -1,4 +1,5 @@
 import dataclasses
+import functools
 import logging
 from dataclasses import dataclass
 from typing import Any, Iterable, Mapping
@@ -84,6 +85,7 @@ class GlobalSPARQLProcessor(Processor):
         self.maybe_apply_inference()
         return evalQuery(self.graph, query, initBindings, base)
 
+    @functools.lru_cache(maxsize=None)
     def load(self, source: str):
         url = URL(source)
 

--- a/iolanta/cyberspace/processor.py
+++ b/iolanta/cyberspace/processor.py
@@ -7,6 +7,7 @@ import owlrl
 import yaml_ld
 from rdflib import (
     DC,
+    DCTERMS,
     FOAF,
     OWL,
     RDF,
@@ -14,7 +15,7 @@ from rdflib import (
     VANN,
     ConjunctiveGraph,
     URIRef,
-    Variable, DCTERMS,
+    Variable,
 )
 from rdflib.plugins.sparql.algebra import translateQuery
 from rdflib.plugins.sparql.evaluate import evalQuery


### PR DESCRIPTION
- Remap `DCTERMS` link
- fmt
- Remember the last non-inferred loaded file
- Add caching for `load()` to speed up operations
