### PR TITLE
72 foaf dna checksum

### DIFF
--- a/iolanta/facets/textual_class/facets.py
+++ b/iolanta/facets/textual_class/facets.py
@@ -6,11 +6,7 @@ from textual.app import ComposeResult
 from textual.containers import Vertical
 from textual.reactive import reactive
 from textual.widget import Widget
-from textual.widgets import (
-    Label,
-    ListItem,
-    ListView,
-)
+from textual.widgets import Label, ListItem, ListView
 
 from iolanta.facets.facet import Facet
 from iolanta.models import NotLiteralNode

--- a/iolanta/facets/textual_default/facets.py
+++ b/iolanta/facets/textual_default/facets.py
@@ -45,7 +45,7 @@ class Content(VerticalScroll):
     """
 
 
-class TextualDefaultFacet(Facet[Widget]):
+class TextualDefaultFacet(Facet[Widget]):   # noqa: WPS214
     """Default rendering engine."""
 
     @functools.cached_property
@@ -162,6 +162,7 @@ class TextualDefaultFacet(Facet[Widget]):
 
     @functools.cached_property
     def properties(self) -> Widget | None:
+        """Render properties table."""
         if not self.grouped_properties:
             return None
 

--- a/iolanta/facets/textual_default/facets.py
+++ b/iolanta/facets/textual_default/facets.py
@@ -196,52 +196,6 @@ class TextualDefaultFacet(Facet[Widget]):   # noqa: WPS214
             yield Label('[i]Properties[/i]', id='properties')
             yield self.properties
 
-
     def show(self) -> Widget:
+        """Render the content."""
         return ContentArea(*self.compose())
-
-
-
-        nodes_for_property = [
-            (row['subject'], row['object'])
-            for row in self.stored_query(
-                'nodes-for-property.sparql',
-                iri=self.iri,
-            )
-        ]
-        if nodes_for_property:
-            rendered_property = self.render(
-                self.iri,
-                environments=[URIRef('https://iolanta.tech/cli/link')],
-            )
-
-            children.append(
-                Label(
-                    '\n[bold]A few nodes connected with this property[/]\n',
-                ),
-            )
-            nodes_table = DataTable(show_header=False, show_cursor=False)
-            nodes_table.add_columns('Subject', 'Property', 'Object')
-            nodes_table.add_rows([
-                (
-                        self.render(
-                            subject_node,
-                            environments=[URIRef('https://iolanta.tech/cli/link')],
-                        ),
-                        rendered_property,
-                        self.render(
-                            object_node,
-                            environments=[URIRef('https://iolanta.tech/cli/link')],
-                        ),
-                )
-                    for subject_node, object_node in nodes_for_property
-            ])
-
-            children.append(nodes_table)
-
-        if self.grouped_properties:
-
-
-            children.append(Label('\n[bold]Properties[/]\n'))
-
-        return Vertical(*children)

--- a/iolanta/facets/textual_default/facets.py
+++ b/iolanta/facets/textual_default/facets.py
@@ -14,7 +14,7 @@ from iolanta.facets.facet import Facet
 from iolanta.models import ComputedQName, NotLiteralNode
 
 
-class Content(VerticalScroll):
+class ContentArea(VerticalScroll):
     """Description of the IRI."""
 
     DEFAULT_CSS = """
@@ -198,7 +198,7 @@ class TextualDefaultFacet(Facet[Widget]):   # noqa: WPS214
 
 
     def show(self) -> Widget:
-        return Content(*self.compose())
+        return ContentArea(*self.compose())
 
 
 

--- a/iolanta/facets/textual_default/facets.py
+++ b/iolanta/facets/textual_default/facets.py
@@ -5,7 +5,7 @@ from typing import Iterable
 import funcy
 from rdflib import DC, RDFS, SDO, URIRef
 from rdflib.term import BNode, Literal, Node
-from textual.containers import Vertical, VerticalScroll
+from textual.containers import VerticalScroll
 from textual.widget import Widget
 from textual.widgets import DataTable, Label, Static
 

--- a/iolanta/facets/textual_link/facet.py
+++ b/iolanta/facets/textual_link/facet.py
@@ -1,4 +1,6 @@
-from rdflib import URIRef
+from rdflib import Literal, URIRef
+from rich.style import Style
+from rich.text import Text
 
 from iolanta.cli.formatters.node_to_qname import node_to_qname
 from iolanta.facets.facet import Facet, FacetOutput
@@ -6,10 +8,13 @@ from iolanta.models import ComputedQName, NotLiteralNode
 
 
 class TextualLinkFacet(Facet[str]):
-    def show(self) -> str:
+    def show(self) -> str | Text:
+        if isinstance(self.iri, Literal):
+            return Text(self.iri, style=Style(color='grey37'))
+
         label = self.render(
             self.iri,
-            environments=[URIRef('https://iolanta.tech/env/title')]
+            environments=[URIRef('https://iolanta.tech/env/title')],
         )
 
         return f'[@click="app.goto(\'{self.iri}\')"]{label}[/]'

--- a/iolanta/facets/textual_link/facet.py
+++ b/iolanta/facets/textual_link/facet.py
@@ -2,13 +2,14 @@ from rdflib import Literal, URIRef
 from rich.style import Style
 from rich.text import Text
 
-from iolanta.cli.formatters.node_to_qname import node_to_qname
-from iolanta.facets.facet import Facet, FacetOutput
-from iolanta.models import ComputedQName, NotLiteralNode
+from iolanta.facets.facet import Facet
 
 
-class TextualLinkFacet(Facet[str]):
+class TextualLinkFacet(Facet[str | Text]):
+    """Render a link within a Textual app."""
+
     def show(self) -> str | Text:
+        """Render the link, or literal text, whatever."""
         if isinstance(self.iri, Literal):
             return Text(self.iri, style=Style(color='grey37'))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,3 +62,10 @@ wemake-python-styleguide = [
     # Save stuff into a dataclass attribute
     "-WPS601",
 ]
+
+
+[tool.flakeheaven.exceptions."**/facets.py"]
+wemake-python-styleguide = [
+    # Found upper-case constant in a class: DEFAULT_CSS
+    "-WPS115",
+]


### PR DESCRIPTION
- Render `Literal` as gray text
- Support `Text` instances as rendered property values
- `j fmt`
- Ignore `WPS115` for facets
- A few linter issues
- Rename `Content` → `ContentArea` to make linters happy
- Remove some dead code
- `flake8` is 🟢
