### PR TITLE
84 browse rdf crashes

### DIFF
--- a/iolanta/data/ontologies-meta.yaml
+++ b/iolanta/data/ontologies-meta.yaml
@@ -30,7 +30,7 @@
           - rdf:langString
           - rdf:language
 
-    - rdfs:Datatype
+    - $id: rdfs:Datatype
     - rdfs:label: Compound Literal
       $reverse:
         rdf:type:

--- a/iolanta/facets/facet.py
+++ b/iolanta/facets/facet.py
@@ -25,6 +25,7 @@ class Facet(Generic[FacetOutput]):
 
     @property
     def stored_queries_path(self) -> Path:
+        """Construct directory for stored queries for this facet."""
         return Path(inspect.getfile(self.__class__)).parent / 'sparql'
 
     @property

--- a/iolanta/facets/facet.py
+++ b/iolanta/facets/facet.py
@@ -21,7 +21,7 @@ class Facet(Generic[FacetOutput]):
     iri: NotLiteralNode
     iolanta: 'iolanta.Iolanta' = field(repr=False)
     environment: Optional[URIRef] = None
-    stack_children: List[Stack] = field(default_factory=list)
+    stack_children: List[Stack] = field(default_factory=list, repr=False)
 
     @property
     def stored_queries_path(self) -> Path:

--- a/iolanta/facets/textual_link/facet.py
+++ b/iolanta/facets/textual_link/facet.py
@@ -11,7 +11,7 @@ class TextualLinkFacet(Facet[str | Text]):
     def show(self) -> str | Text:
         """Render the link, or literal text, whatever."""
         if isinstance(self.iri, Literal):
-            return Text(self.iri, style=Style(color='grey37'))
+            return f'[b grey37]{self.iri}[/b grey37]'
 
         label = self.render(
             self.iri,


### PR DESCRIPTION
- Hide stack from facet repr
- `rdf:` crushes no more
