### PR TITLE
98 load class instances lazily

### DIFF
--- a/iolanta/facets/textual_class/facets.py
+++ b/iolanta/facets/textual_class/facets.py
@@ -3,9 +3,9 @@ from functools import cached_property
 from typing import ClassVar
 
 import funcy
-from rdflib import URIRef, RDF
+from rdflib import RDF, URIRef
 from textual.app import ComposeResult
-from textual.binding import BindingType, Binding
+from textual.binding import Binding, BindingType
 from textual.containers import Vertical
 from textual.scrollbar import ScrollDown
 from textual.widget import Widget

--- a/iolanta/facets/textual_class/facets.py
+++ b/iolanta/facets/textual_class/facets.py
@@ -52,6 +52,24 @@ class InstanceItem(ListItem):
         self.run_worker(self.render_content, thread=True, exclusive=True)
 
 
+def indices_around(center: int, radius: int):
+    """
+    Generate indices around a center index within a given radius.
+
+    Args:
+        center (int): The center index around which to generate indices.
+        radius (int): The maximum distance from the center.
+
+    Yields:
+        int: The next valid index around the center within the specified radius.
+    """
+    directions = [-1, 1]
+    yield center
+    for render_radius in range(1, radius + 1):
+        for direction in directions:
+            yield center + direction * render_radius
+
+
 class InstancesList(ListView):
     """Instances list."""
 
@@ -86,24 +104,8 @@ class InstancesList(ListView):
 
     def render_instances(self):
         """Render a number of instances around the one that is highlighted."""
-        max_render_radius = 10
-        if self.index:
-            self.highlighted_child.resolve()
-            highlighted_index = self.index
-        else:
-            highlighted_index = 0
-
-        for render_radius in range(1, max_render_radius + 1):
-            directions = [-1, 1]
-            for direction in directions:
-                index = highlighted_index + direction * render_radius
-
-                if index < 0:
-                    continue
-
-                if index >= len(self.instances):
-                    continue
-
+        for index in indices_around(self.index or 0, 10):
+            if 0 < index <= len(self.instances):
                 self._nodes[index].resolve()
 
     def on_mount(self):

--- a/iolanta/facets/textual_class/facets.py
+++ b/iolanta/facets/textual_class/facets.py
@@ -1,30 +1,74 @@
+import functools
 from functools import cached_property
+from typing import ClassVar
 
 import funcy
-from rdflib import BNode, URIRef
+from rdflib import URIRef, RDF
 from textual.app import ComposeResult
-from textual.reactive import reactive
+from textual.binding import BindingType, Binding
+from textual.containers import Vertical
+from textual.scrollbar import ScrollDown
 from textual.widget import Widget
 from textual.widgets import Label, ListItem, ListView
 
 from iolanta.facets.facet import Facet
+from iolanta.facets.textual_default.facets import TripleURIRef
 from iolanta.models import NotLiteralNode
+
+
+class InstanceItem(ListItem):
+    def __init__(self, node: NotLiteralNode, parent_class: NotLiteralNode):
+        self.node = node
+        self.parent_class = parent_class
+        self.is_resolved = False
+        super().__init__()
+
+    def compose(self) -> ComposeResult:
+        yield Label(str(self.node))
+
+    def render_content(self):
+        renderable = self.app.iolanta.render(
+            self.node,
+            environments=[URIRef('https://iolanta.tech/env/title')],
+        )[0]
+        self.app.call_from_thread(
+            self.query_one(Label).update,
+            renderable,
+        )
+        self.is_resolved = True
+
+    def resolve(self):
+        """Resolve the node for this item and render it."""
+        if self.is_resolved:
+            return
+
+        self.run_worker(self.render_content, thread=True, exclusive=True)
 
 
 class InstancesList(ListView):
     """Instances list."""
 
-    instances = reactive[list[BNode | URIRef]](list, init=False)  # noqa: WPS462
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding('enter', 'goto', 'Goto'),
+        Binding('p', 'provenance', 'Provenan©e'),
+    ]
+
+    def __init__(
+        self,
+        instances: list[NotLiteralNode],
+        parent_class: NotLiteralNode,
+    ):
+        self.instances = instances
+        self.parent_class = parent_class
+        super().__init__()
 
     @cached_property
     def list_item_by_instance(self) -> dict[NotLiteralNode, ListItem]:
         """Generate a ListItem per class instance."""
         return {
-            instance: ListItem(
-                Label(
-                    f'[red]…[/red] {instance}',
-                ),
-                disabled=True,
+            instance: InstanceItem(
+                node=instance,
+                parent_class=self.parent_class,
             )
             for instance in self.instances
         }
@@ -33,26 +77,49 @@ class InstancesList(ListView):
         yield from self.list_item_by_instance.values()
 
     def render_instances(self):
-        for instance, list_item in self.list_item_by_instance.items():
-            list_item.query_one(Label).renderable = '⏳ Loading…'
+        max_render_radius = 10
+        if self.index:
+            self.highlighted_child.resolve()
+            highlighted_index = self.index
+        else:
+            highlighted_index = 0
 
-            try:
-                rendered = self.app.iolanta.render(
-                    instance,
-                    environments=[URIRef('https://iolanta.tech/cli/link')],
-                )[0]
-            except Exception as rendering_error:
-                self.log(f'Failed to render {instance}: {rendering_error}')
-                rendered = f'💥 {instance}'
+        for render_radius in range(1, max_render_radius + 1):
+            for direction in [-1, 1]:
+                index = highlighted_index + direction * render_radius
 
-            label = Label(rendered)
+                if index < 0:
+                    continue
 
-            self.app.call_from_thread(list_item.remove_children)
-            self.app.call_from_thread(list_item.mount, label)
-            list_item.disabled = False
+                if index >= len(self.instances):
+                    continue
+
+                self._nodes[index].resolve()
 
     def on_mount(self):
-        self.run_worker(self.render_instances, thread=True)
+        self.run_worker(self.render_instances, thread=True, exclusive=True)
+
+    def on_list_view_selected(self):
+        self.run_worker(self.render_instances, thread=True, exclusive=True)
+
+    def on_list_item__child_clicked(self, event: ListItem._ChildClicked) -> None:
+        """Navigate on click."""
+        # FIXME if we call `action_goto()` here we'll navigate to the item that
+        #   was selected _prior_ to this click.
+
+    def action_goto(self):
+        """Navigate."""
+        self.app.action_goto(self.highlighted_child.node)
+
+    def action_provenance(self):
+        """Navigate to provenance for the property value."""
+        self.app.action_goto(
+            TripleURIRef.from_triple(
+                subject=self.highlighted_child.node,
+                predicate=RDF.type,
+                object_=self.parent_class,
+            ),
+        )
 
 
 class Class(Facet[Widget]):
@@ -61,8 +128,12 @@ class Class(Facet[Widget]):
             'instance',
             self.stored_query('instances.sparql', iri=self.iri),
         )
+        count = len(instances)
 
-        instances_list = InstancesList()
-        instances_list.instances = instances
-
-        return instances_list
+        return Vertical(
+            Label(f'{count}+ instances'),
+            InstancesList(
+                instances=instances,
+                parent_class=self.iri,
+            ),
+        )

--- a/iolanta/facets/textual_class/facets.py
+++ b/iolanta/facets/textual_class/facets.py
@@ -13,6 +13,8 @@ from iolanta.facets.facet import Facet
 from iolanta.facets.textual_default.facets import TripleURIRef
 from iolanta.models import NotLiteralNode
 
+INSTANCE_RENDER_RADIUS = 50
+
 
 class InstanceItem(ListItem):
     """An item in class instances list."""
@@ -66,11 +68,11 @@ def indices_around(center: int, radius: int):
     directions = [-1, 1]
     yield center
     for render_radius in range(1, radius + 1):
-        for direction in directions:
+        for direction in directions:   # noqa: WPS526
             yield center + direction * render_radius
 
 
-class InstancesList(ListView):
+class InstancesList(ListView):   # noqa: WPS214
     """Instances list."""
 
     BINDINGS: ClassVar[list[BindingType]] = [
@@ -104,17 +106,19 @@ class InstancesList(ListView):
 
     def render_instances(self):
         """Render a number of instances around the one that is highlighted."""
-        for index in indices_around(self.index or 0, 10):
+        for index in indices_around(self.index or 0, INSTANCE_RENDER_RADIUS):
             if 0 < index <= len(self.instances):
                 self._nodes[index].resolve()
 
     def on_mount(self):
+        """Render a part of the list on creation."""
         self.run_worker(self.render_instances, thread=True, exclusive=True)
 
     def on_list_view_selected(self):
+        """Render a part of the list on selection."""
         self.run_worker(self.render_instances, thread=True, exclusive=True)
 
-    def on_list_item__child_clicked(self) -> None:
+    def on_list_item__child_clicked(self) -> None:   # noqa: WPS116
         """Navigate on click."""
         # FIXME if we call `action_goto()` here we'll navigate to the item that
         #   was selected _prior_ to this click.
@@ -138,6 +142,7 @@ class Class(Facet[Widget]):
     """Render instances of a class."""
 
     def show(self) -> Widget:
+        """Render the instances list."""
         instances = funcy.lpluck(
             'instance',
             self.stored_query('instances.sparql', iri=self.iri),

--- a/iolanta/facets/textual_class/sparql/instances.sparql
+++ b/iolanta/facets/textual_class/sparql/instances.sparql
@@ -1,3 +1,5 @@
 SELECT ?instance WHERE {
     ?instance a $iri .
+
+    FILTER(!isLiteral(?instance)) .
 } ORDER BY ?instance


### PR DESCRIPTION
- Render class instances lazily
- `j fmt`
- Fix a few linter issues
- ➕ `indices_around()`
- `flake8` is now 🟢
