### PR TITLE
133 flip

### DIFF
--- a/docs/blog/flip-menu.md
+++ b/docs/blog/flip-menu.md
@@ -1,0 +1,25 @@
+---
+title: Use bottom menu to flip facets
+date: 2024-10-13
+overrides: flip.md
+---
+
+## Context
+
+We need some way to flip from one facet to another, regardless of the implementation of the facet itself.
+
+## Decision
+
+Display alternative facets in the bottom menu.
+
+## Consequences
+
+### Pro
+
+* Easy to implement, no extra widgets needed
+
+### Contra
+
+* Might be too many facets there
+  * There are not that many facets right now, we do not care so far
+  * Later we can expand this to a special menu or whatever

--- a/docs/blog/flip.md
+++ b/docs/blog/flip.md
@@ -1,0 +1,40 @@
+---
+date: 2024-10-04
+title: Flip
+---
+
+## Context
+
+I need to flip between facets when looking at the same node.
+
+A few changes needed for that.
+
+```mermaid
+graph TD
+    env-to-type("<code>environment</code> → <code>rdf:Datatype</code>") --> subtypes("Subtypes<br/><em>Anything there already?</em>") --> generic("Generic types")
+    subtypes --> dependent("Dependent/parametric types") --> propagate("Propagate params downward?") 
+    env-to-type --- no-viewpoints("Viewpoints<br/>no longer needed!")
+    subtypes --> json("Use <code>rdf:JSON</code>!")
+    subtypes --> mro("Multiple inheritance?")
+    
+    subtypes --> widget("<code>TextualWidget</code>")
+    click widget "https://textual.textualize.io/guide/widgets/"
+    
+    widget --"is supertype of"-->full-screen("<code>TextualFullScreenWidget</code>")
+    
+    full-screen --> downward("Target type: search downward")
+    full-screen --> upward("hasInstanceFacet: search upward<br/>or just rely upon OWL")
+    
+    env-to-type --> facet-url("URL encapsulating the facet to use") --> flip("[f] Flip menu")
+    facet-url --> facet-parameters("How does facet know rendering/type params???")
+    facet-parameters --> table("Want to render countries as table")
+    table --> viewpoint("Table is a viewpoint node, we render it")
+    table --> table-type("Table is a type")
+    
+```
+
+## Decision
+
+* [ ] Create and call a Flip page to list all applicable facets
+* [ ] Run specific facet on click
+* [ ] And then work on env → type migration

--- a/iolanta/data/textual-browser.yaml
+++ b/iolanta/data/textual-browser.yaml
@@ -5,7 +5,7 @@
 - $id: https://iolanta.tech/cli/textual
   iolanta:hasDefaultFacet:
     $id: python://iolanta.facets.textual_default.TextualDefaultFacet
-    rdfs:label: "Goo"
+    rdfs:label: Properties
 
 - $id: "urn:"
   iolanta:hasFacetByPrefix:
@@ -31,8 +31,9 @@
 - $id: owl:Ontology
   iolanta:hasInstanceFacet:
     $id: python://iolanta.facets.textual_ontology.OntologyFacet
+    rdfs:label: Ontology
     iolanta:supports:
-      $id: https://iolanta.tech/cli/default/terms
+      $id: https://iolanta.tech/cli/textual
 
 - $id: https://iolanta.tech/qname
   iolanta:hasDefaultFacet:

--- a/iolanta/data/textual-browser.yaml
+++ b/iolanta/data/textual-browser.yaml
@@ -5,6 +5,7 @@
 - $id: https://iolanta.tech/cli/textual
   iolanta:hasDefaultFacet:
     $id: python://iolanta.facets.textual_default.TextualDefaultFacet
+    rdfs:label: "Goo"
 
 - $id: "urn:"
   iolanta:hasFacetByPrefix:
@@ -23,8 +24,9 @@
 - $id: rdfs:Class
   iolanta:hasInstanceFacet:
     $id: python://iolanta.facets.textual_class.Class
+    rdfs:label: Instances
     iolanta:supports:
-      $id: https://iolanta.tech/cli/default/instances
+      $id: https://iolanta.tech/cli/textual
 
 - $id: owl:Ontology
   iolanta:hasInstanceFacet:

--- a/iolanta/facets/locator.py
+++ b/iolanta/facets/locator.py
@@ -152,6 +152,7 @@ class FacetFinder:
             key=self.row_sorter_by_environment,
         )
 
+    @funcy.post_processing(list)
     def choices(self) -> Iterable[FoundRow]:
         """Compose a stream of all possible facet choices."""
         yield from self.by_prefix()

--- a/iolanta/facets/textual_browser/app.py
+++ b/iolanta/facets/textual_browser/app.py
@@ -7,7 +7,6 @@ from typing import cast
 from rdflib import BNode, URIRef
 from rdflib.term import Node
 from textual.app import App, ComposeResult
-from textual.binding import Binding, BindingsMap
 from textual.containers import ScrollableContainer
 from textual.widgets import ContentSwitcher, Footer, Header, Placeholder, Static
 from textual.worker import Worker, WorkerState
@@ -61,7 +60,12 @@ class Page(ScrollableContainer):
         super().__init__(renderable, id=page_id)
         for number, flip_option in enumerate(flip_options, start=1):
             self._bindings.bind(
-                keys=f'{number}',  # Nothing else works
+                keys={
+                    1: 'ctrl+j',
+                    2: 'ctrl+k',
+                    3: 'ctrl+l',
+                    4: 'ctrl+;',
+                }[number],
                 description=flip_option.title,
                 action=(
                     f"app.goto('{iri}', None, "

--- a/iolanta/iolanta.py
+++ b/iolanta/iolanta.py
@@ -21,7 +21,6 @@ from rdflib.term import Node
 
 from iolanta import entry_points
 from iolanta.cli.formatters.node_to_qname import node_to_qname
-from iolanta.errors import InsufficientDataForRender
 from iolanta.facets.errors import FacetError
 from iolanta.facets.facet import Facet
 from iolanta.facets.locator import FacetFinder
@@ -246,9 +245,6 @@ class Iolanta:   # noqa: WPS214
 
         try:
             return facet.show(), facet.stack
-
-        except InsufficientDataForRender:
-            raise
 
         except Exception as err:
             raise FacetError(

--- a/iolanta/iolanta.py
+++ b/iolanta/iolanta.py
@@ -140,7 +140,7 @@ class Iolanta:   # noqa: WPS214
 
         return self
 
-    def infer(self, closure_class) -> 'Iolanta':
+    def infer(self, closure_class=None) -> 'Iolanta':
         """
         Apply inference.
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -3365,17 +3365,18 @@ test = ["django", "mypy", "pytest (>=7.1)", "pytest-cov", "pytest-django", "sybi
 
 [[package]]
 name = "textual"
-version = "0.75.1"
+version = "0.83.0"
 description = "Modern Text User Interface framework"
 optional = false
 python-versions = "<4.0.0,>=3.8.1"
 files = [
-    {file = "textual-0.75.1-py3-none-any.whl", hash = "sha256:7edb1196753feae79890daa2287bc3180ebba2cbf63f59f2a160991325b020f2"},
-    {file = "textual-0.75.1.tar.gz", hash = "sha256:3f0b53fe6119aa64853c7e60ced4d4e16fb23c83dee1e0fd19eddb3f2639c02e"},
+    {file = "textual-0.83.0-py3-none-any.whl", hash = "sha256:d6efc1e5c54086fd0a4fe274f18b5638ca24a69325c07e1b4400a7d0a1a14c55"},
+    {file = "textual-0.83.0.tar.gz", hash = "sha256:fc3b97796092d9c7e685e5392f38f3eb2007ffe1b3b1384dee6d3f10d256babd"},
 ]
 
 [package.dependencies]
 markdown-it-py = {version = ">=2.1.0", extras = ["linkify", "plugins"]}
+platformdirs = ">=3.6.0,<5"
 rich = ">=13.3.3"
 typing-extensions = ">=4.4.0,<5.0.0"
 
@@ -3762,4 +3763,4 @@ all = ["iolanta-tables"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "166335275c00bdc901457c68e8bccb9ebcb749fea22efaaec9032e40bfecf307"
+content-hash = "53ae758b330cb3b2809eedcc7329dd37429557401ca29e7a6904cc123b33904f"

--- a/poetry.lock
+++ b/poetry.lock
@@ -159,6 +159,24 @@ files = [
 ]
 
 [[package]]
+name = "asttokens"
+version = "2.4.1"
+description = "Annotate AST trees with source code positions"
+optional = false
+python-versions = "*"
+files = [
+    {file = "asttokens-2.4.1-py2.py3-none-any.whl", hash = "sha256:051ed49c3dcae8913ea7cd08e46a606dba30b79993209636c4875bc1d637bc24"},
+    {file = "asttokens-2.4.1.tar.gz", hash = "sha256:b03869718ba9a6eb027e134bfdf69f38a236d681c83c160d510768af11254ba0"},
+]
+
+[package.dependencies]
+six = ">=1.12.0"
+
+[package.extras]
+astroid = ["astroid (>=1,<2)", "astroid (>=2,<4)"]
+test = ["astroid (>=1,<2)", "astroid (>=2,<4)", "pytest"]
+
+[[package]]
 name = "async-timeout"
 version = "4.0.3"
 description = "Timeout context manager for asyncio programs"
@@ -691,6 +709,17 @@ files = [
 ]
 
 [[package]]
+name = "decorator"
+version = "5.1.1"
+description = "Decorators for Humans"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},
+    {file = "decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"},
+]
+
+[[package]]
 name = "deepmerge"
 version = "0.1.1"
 description = "a toolset to deeply merge python dictionaries."
@@ -790,6 +819,20 @@ files = [
 
 [package.extras]
 test = ["pytest (>=6)"]
+
+[[package]]
+name = "executing"
+version = "2.1.0"
+description = "Get the currently executing AST node of a frame, and other information"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "executing-2.1.0-py2.py3-none-any.whl", hash = "sha256:8d63781349375b5ebccc3142f4b30350c0cd9c79f921cde38be2be4637e98eaf"},
+    {file = "executing-2.1.0.tar.gz", hash = "sha256:8ea27ddd260da8150fa5a708269c4a10e76161e2496ec3e587da9e3c0fe4b9ab"},
+]
+
+[package.extras]
+tests = ["asttokens (>=2.1.0)", "coverage", "coverage-enable-subprocess", "ipython", "littleutils", "pytest", "rich"]
 
 [[package]]
 name = "filelock"
@@ -1285,6 +1328,44 @@ dominate = ">=2.7.0,<3.0.0"
 iolanta = ">=1.0.11,<2.0.0"
 
 [[package]]
+name = "ipython"
+version = "8.28.0"
+description = "IPython: Productive Interactive Computing"
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "ipython-8.28.0-py3-none-any.whl", hash = "sha256:530ef1e7bb693724d3cdc37287c80b07ad9b25986c007a53aa1857272dac3f35"},
+    {file = "ipython-8.28.0.tar.gz", hash = "sha256:0d0d15ca1e01faeb868ef56bc7ee5a0de5bd66885735682e8a322ae289a13d1a"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+decorator = "*"
+exceptiongroup = {version = "*", markers = "python_version < \"3.11\""}
+jedi = ">=0.16"
+matplotlib-inline = "*"
+pexpect = {version = ">4.3", markers = "sys_platform != \"win32\" and sys_platform != \"emscripten\""}
+prompt-toolkit = ">=3.0.41,<3.1.0"
+pygments = ">=2.4.0"
+stack-data = "*"
+traitlets = ">=5.13.0"
+typing-extensions = {version = ">=4.6", markers = "python_version < \"3.12\""}
+
+[package.extras]
+all = ["ipython[black,doc,kernel,matplotlib,nbconvert,nbformat,notebook,parallel,qtconsole]", "ipython[test,test-extra]"]
+black = ["black"]
+doc = ["docrepr", "exceptiongroup", "intersphinx-registry", "ipykernel", "ipython[test]", "matplotlib", "setuptools (>=18.5)", "sphinx (>=1.3)", "sphinx-rtd-theme", "sphinxcontrib-jquery", "tomli", "typing-extensions"]
+kernel = ["ipykernel"]
+matplotlib = ["matplotlib"]
+nbconvert = ["nbconvert"]
+nbformat = ["nbformat"]
+notebook = ["ipywidgets", "notebook"]
+parallel = ["ipyparallel"]
+qtconsole = ["qtconsole"]
+test = ["packaging", "pickleshare", "pytest", "pytest-asyncio (<0.22)", "testpath"]
+test-extra = ["curio", "ipython[test]", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.23)", "pandas", "trio"]
+
+[[package]]
 name = "isodate"
 version = "0.6.1"
 description = "An ISO 8601 date/time/duration parser and formatter"
@@ -1311,6 +1392,25 @@ files = [
 
 [package.extras]
 colors = ["colorama (>=0.4.6)"]
+
+[[package]]
+name = "jedi"
+version = "0.19.1"
+description = "An autocompletion tool for Python that can be used for text editors."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "jedi-0.19.1-py2.py3-none-any.whl", hash = "sha256:e983c654fe5c02867aef4cdfce5a2fbb4a50adc0af145f70504238f18ef5e7e0"},
+    {file = "jedi-0.19.1.tar.gz", hash = "sha256:cf0496f3651bc65d7174ac1b7d043eff454892c708a87d1b683e57b569927ffd"},
+]
+
+[package.dependencies]
+parso = ">=0.8.3,<0.9.0"
+
+[package.extras]
+docs = ["Jinja2 (==2.11.3)", "MarkupSafe (==1.1.1)", "Pygments (==2.8.1)", "alabaster (==0.7.12)", "babel (==2.9.1)", "chardet (==4.0.0)", "commonmark (==0.8.1)", "docutils (==0.17.1)", "future (==0.18.2)", "idna (==2.10)", "imagesize (==1.2.0)", "mock (==1.0.1)", "packaging (==20.9)", "pyparsing (==2.4.7)", "pytz (==2021.1)", "readthedocs-sphinx-ext (==2.1.4)", "recommonmark (==0.5.0)", "requests (==2.25.1)", "six (==1.15.0)", "snowballstemmer (==2.1.0)", "sphinx (==1.8.5)", "sphinx-rtd-theme (==0.4.3)", "sphinxcontrib-serializinghtml (==1.1.4)", "sphinxcontrib-websupport (==1.2.4)", "urllib3 (==1.26.4)"]
+qa = ["flake8 (==5.0.4)", "mypy (==0.971)", "types-setuptools (==67.2.0.1)"]
+testing = ["Django", "attrs", "colorama", "docopt", "pytest (<7.0.0)"]
 
 [[package]]
 name = "jeeves-shell"
@@ -1683,6 +1783,20 @@ packaging = ">=17.0"
 dev = ["marshmallow[tests]", "pre-commit (>=3.5,<4.0)", "tox"]
 docs = ["alabaster (==0.7.16)", "autodocsumm (==0.2.12)", "sphinx (==7.3.7)", "sphinx-issues (==4.1.0)", "sphinx-version-warning (==1.1.2)"]
 tests = ["pytest", "pytz", "simplejson"]
+
+[[package]]
+name = "matplotlib-inline"
+version = "0.1.7"
+description = "Inline Matplotlib backend for Jupyter"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "matplotlib_inline-0.1.7-py3-none-any.whl", hash = "sha256:df192d39a4ff8f21b1895d72e6a13f5fcc5099f00fa84384e0ea28c2cc0653ca"},
+    {file = "matplotlib_inline-0.1.7.tar.gz", hash = "sha256:8423b23ec666be3d16e16b60bdd8ac4e86e840ebd1dd11a30b9f117f2fa0ab90"},
+]
+
+[package.dependencies]
+traitlets = "*"
 
 [[package]]
 name = "mccabe"
@@ -2217,6 +2331,21 @@ files = [
 ]
 
 [[package]]
+name = "parso"
+version = "0.8.4"
+description = "A Python Parser"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "parso-0.8.4-py2.py3-none-any.whl", hash = "sha256:a418670a20291dacd2dddc80c377c5c3791378ee1e8d12bffc35420643d43f18"},
+    {file = "parso-0.8.4.tar.gz", hash = "sha256:eb3a7b58240fb99099a345571deecc0f9540ea5f4dd2fe14c2a99d6b281ab92d"},
+]
+
+[package.extras]
+qa = ["flake8 (==5.0.4)", "mypy (==0.971)", "types-setuptools (==67.2.0.1)"]
+testing = ["docopt", "pytest"]
+
+[[package]]
 name = "pathspec"
 version = "0.12.1"
 description = "Utility library for gitignore style pattern matching of file paths."
@@ -2253,6 +2382,20 @@ files = [
 flake8 = ">=3.9.1"
 
 [[package]]
+name = "pexpect"
+version = "4.9.0"
+description = "Pexpect allows easy control of interactive console applications."
+optional = false
+python-versions = "*"
+files = [
+    {file = "pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523"},
+    {file = "pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f"},
+]
+
+[package.dependencies]
+ptyprocess = ">=0.5"
+
+[[package]]
 name = "platformdirs"
 version = "4.2.2"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
@@ -2282,6 +2425,45 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.48"
+description = "Library for building powerful interactive command lines in Python"
+optional = false
+python-versions = ">=3.7.0"
+files = [
+    {file = "prompt_toolkit-3.0.48-py3-none-any.whl", hash = "sha256:f49a827f90062e411f1ce1f854f2aedb3c23353244f8108b89283587397ac10e"},
+    {file = "prompt_toolkit-3.0.48.tar.gz", hash = "sha256:d6623ab0477a80df74e646bdbc93621143f5caf104206aa29294d53de1a03d90"},
+]
+
+[package.dependencies]
+wcwidth = "*"
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+description = "Run a subprocess in a pseudo terminal"
+optional = false
+python-versions = "*"
+files = [
+    {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
+    {file = "ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"},
+]
+
+[[package]]
+name = "pure-eval"
+version = "0.2.3"
+description = "Safely evaluate AST nodes without side effects"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0"},
+    {file = "pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42"},
+]
+
+[package.extras]
+tests = ["pytest"]
 
 [[package]]
 name = "pycodestyle"
@@ -3119,6 +3301,25 @@ files = [
 ]
 
 [[package]]
+name = "stack-data"
+version = "0.6.3"
+description = "Extract data from python stack frames and tracebacks for informative displays"
+optional = false
+python-versions = "*"
+files = [
+    {file = "stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695"},
+    {file = "stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9"},
+]
+
+[package.dependencies]
+asttokens = ">=2.1.0"
+executing = ">=1.2.0"
+pure-eval = "*"
+
+[package.extras]
+tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
+
+[[package]]
 name = "stevedore"
 version = "5.2.0"
 description = "Manage dynamic plugins for Python applications"
@@ -3242,6 +3443,21 @@ files = [
     {file = "tomlkit-0.13.0-py3-none-any.whl", hash = "sha256:7075d3042d03b80f603482d69bf0c8f345c2b30e41699fd8883227f89972b264"},
     {file = "tomlkit-0.13.0.tar.gz", hash = "sha256:08ad192699734149f5b97b45f1f18dad7eb1b6d16bc72ad0c2335772650d7b72"},
 ]
+
+[[package]]
+name = "traitlets"
+version = "5.14.3"
+description = "Traitlets Python configuration system"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f"},
+    {file = "traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7"},
+]
+
+[package.extras]
+docs = ["myst-parser", "pydata-sphinx-theme", "sphinx"]
+test = ["argcomplete (>=3.0.3)", "mypy (>=1.7.0)", "pre-commit", "pytest (>=7.0,<8.2)", "pytest-mock", "pytest-mypy-testing"]
 
 [[package]]
 name = "typer"
@@ -3373,6 +3589,17 @@ files = [
 
 [package.dependencies]
 bracex = ">=2.1.1"
+
+[[package]]
+name = "wcwidth"
+version = "0.2.13"
+description = "Measures the displayed width of unicode strings in a terminal"
+optional = false
+python-versions = "*"
+files = [
+    {file = "wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859"},
+    {file = "wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5"},
+]
 
 [[package]]
 name = "wemake-python-styleguide"
@@ -3535,4 +3762,4 @@ all = ["iolanta-tables"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "ab6478e55dff47b1466a9c18085a4ecb575e5f85c3fa52f1c153f7148ffcb6bd"
+content-hash = "166335275c00bdc901457c68e8bccb9ebcb749fea22efaaec9032e40bfecf307"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ more-itertools = "^9.0.0"
 owlrl = "^6.0.2"
 funcy = "^2.0"
 rich = "^13.3.1"
-textual = ">=0.47.1"
+textual = "^0.83.0"
 iolanta-tables = {version = "^0.1.7", optional = true}
 yarl = ">=1.9.4"
 boltons = "^24.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ mkdocs-awesome-pages-plugin = "^2.9.2"
 mkdocs-blogging-plugin = "^2.2.11"
 mkdocstrings-python = "^1.8.0"
 textual-dev = ">=1.5.1"
+ipython = "^8.28.0"
 
 [tool.poetry.extras]
 all = ["iolanta-tables"]


### PR DESCRIPTION
- ➕ `ipython` dev dependency
- `Iolanta().infer()` is now not crashing
- ➕ Draft Flip ADR
- Document flip options in bottom menu
- `FacetFinder().choices()` outputs a `list` now
- React on multiple available facets per page
- `InsufficientDataForRender` is a no op
- Define title for `Instances` facet
- ➕ `FlipOption` and bindings from that
- Upgrade `textual` to latest version
- Default facet is now named `Properties`
- Use `jkl;` keys to flip facets
