### PR TITLE
137 render as datatype

### DIFF
--- a/iolanta/cli/main.py
+++ b/iolanta/cli/main.py
@@ -74,7 +74,7 @@ def render_command(
     try:
         renderable, stack = iolanta.render(
             node=node,
-            environments=[
+            as_datatype=[
                 iolanta.string_to_node(environment),
             ],
         )

--- a/iolanta/cli/main.py
+++ b/iolanta/cli/main.py
@@ -74,9 +74,7 @@ def render_command(
     try:
         renderable, stack = iolanta.render(
             node=node,
-            as_datatype=[
-                iolanta.string_to_node(environment),
-            ],
+            as_datatype=iolanta.string_to_node(environment),
         )
 
     except DocumentedError as documented_error:

--- a/iolanta/facets/cli/record.py
+++ b/iolanta/facets/cli/record.py
@@ -19,7 +19,7 @@ class Record(RichFacet):
     def show(self) -> Renderable:
         rows = self.stored_query('record.sparql', node=self.iri)
 
-        caption = self.render(self.iri, environments=[IOLANTA['cli/record/title']])
+        caption = self.render(self.iri, as_datatype=[IOLANTA['cli/record/title']])
 
         table = Table(
             show_header=False,
@@ -37,11 +37,11 @@ class Record(RichFacet):
         for row in rows:
             rendered_property = self.render(
                 row['property'],
-                environments=[IOLANTA['cli/record/property']],
+                as_datatype=[IOLANTA['cli/record/property']],
             )
             rendered_value = self.render(
                 row['value'],
-                environments=[IOLANTA['cli/record/value']],
+                as_datatype=[IOLANTA['cli/record/value']],
             )
             table.add_row(rendered_property, rendered_value)
 

--- a/iolanta/facets/cli/record.py
+++ b/iolanta/facets/cli/record.py
@@ -17,9 +17,10 @@ class Record(RichFacet):
     )
 
     def show(self) -> Renderable:
+        return "RECORD"
         rows = self.stored_query('record.sparql', node=self.iri)
 
-        caption = self.render(self.iri, as_datatype=IOLANTA['cli/record/title'])
+        caption = self.render(self.iri, as_datatype=IOLANTA['cli/title'])
 
         table = Table(
             show_header=False,

--- a/iolanta/facets/cli/record.py
+++ b/iolanta/facets/cli/record.py
@@ -19,7 +19,7 @@ class Record(RichFacet):
     def show(self) -> Renderable:
         rows = self.stored_query('record.sparql', node=self.iri)
 
-        caption = self.render(self.iri, as_datatype=[IOLANTA['cli/record/title']])
+        caption = self.render(self.iri, as_datatype=IOLANTA['cli/record/title'])
 
         table = Table(
             show_header=False,
@@ -37,11 +37,11 @@ class Record(RichFacet):
         for row in rows:
             rendered_property = self.render(
                 row['property'],
-                as_datatype=[IOLANTA['cli/record/property']],
+                as_datatype=IOLANTA['cli/record/property'],
             )
             rendered_value = self.render(
                 row['value'],
-                as_datatype=[IOLANTA['cli/record/value']],
+                as_datatype=IOLANTA['cli/record/value'],
             )
             table.add_row(rendered_property, rendered_value)
 

--- a/iolanta/facets/errors.py
+++ b/iolanta/facets/errors.py
@@ -114,7 +114,7 @@ class FacetNotFound(DocumentedError):
     """
 
     node: Node
-    as_datatype: List[NotLiteralNode]
+    as_datatype: NotLiteralNode
     node_types: List[NotLiteralNode] = field(default_factory=list)
 
     @property

--- a/iolanta/facets/errors.py
+++ b/iolanta/facets/errors.py
@@ -114,7 +114,7 @@ class FacetNotFound(DocumentedError):
     """
 
     node: Node
-    environments: List[NotLiteralNode]
+    as_datatype: List[NotLiteralNode]
     node_types: List[NotLiteralNode] = field(default_factory=list)
 
     @property

--- a/iolanta/facets/errors.py
+++ b/iolanta/facets/errors.py
@@ -149,10 +149,13 @@ class FacetError(DocumentedError):
     @property
     def indented_error(self):
         """Format the underlying error text."""
-        return textwrap.indent(
-            str(self.error),
-            prefix='    ',
-        )
+        try:
+            return textwrap.indent(
+                str(self.error),
+                prefix='    ',
+            )
+        except Exception:
+            return '(failing while rendering)'
 
 
 @dataclass

--- a/iolanta/facets/errors.py
+++ b/iolanta/facets/errors.py
@@ -110,7 +110,7 @@ class FacetNotFound(DocumentedError):
     No way to render the node you asked for.
 
     - **Node:** `{self.node}` *({self.node_type})*
-    - **Environments tried:** `{self.environments}`
+    - **Output datatype:** `{self.as_datatype}`
     """
 
     node: Node

--- a/iolanta/facets/facet.py
+++ b/iolanta/facets/facet.py
@@ -55,12 +55,12 @@ class Facet(Generic[FacetOutput]):
     def render(
         self,
         node: Union[str, Node],
-        environments: Optional[Union[str, List[NotLiteralNode]]] = None,
+        as_datatype: Optional[Union[str, List[NotLiteralNode]]] = None,
     ) -> Any:
         """Shortcut to render something via iolanta."""
         rendered, stack = self.iolanta.render(
             node=node,
-            as_datatype=environments,
+            as_datatype=as_datatype,
         )
 
         self.stack_children.append(stack)

--- a/iolanta/facets/facet.py
+++ b/iolanta/facets/facet.py
@@ -60,7 +60,7 @@ class Facet(Generic[FacetOutput]):
         """Shortcut to render something via iolanta."""
         rendered, stack = self.iolanta.render(
             node=node,
-            environments=environments,
+            as_datatype=environments,
         )
 
         self.stack_children.append(stack)

--- a/iolanta/facets/generic/default.py
+++ b/iolanta/facets/generic/default.py
@@ -52,7 +52,7 @@ class DefaultMixin(Facet[FacetOutput]):
         if symbol := self.description.symbol:
             rendered_symbol = self.render(
                 symbol,
-                as_datatype=[self.environment],
+                as_datatype=self.environment,
             )
             label = f'{rendered_symbol} {label}'
 

--- a/iolanta/facets/generic/default.py
+++ b/iolanta/facets/generic/default.py
@@ -52,7 +52,7 @@ class DefaultMixin(Facet[FacetOutput]):
         if symbol := self.description.symbol:
             rendered_symbol = self.render(
                 symbol,
-                environments=[self.environment],
+                as_datatype=[self.environment],
             )
             label = f'{rendered_symbol} {label}'
 

--- a/iolanta/facets/locator.py
+++ b/iolanta/facets/locator.py
@@ -23,12 +23,12 @@ class FacetFinder:
 
     iolanta: 'iolanta.Iolanta'    # type: ignore
     node: Node
-    environments: List[NotLiteralNode]
+    as_datatype: List[NotLiteralNode]
 
     @cached_property
     def row_sorter_by_environment(self):
         def _sorter(row) -> int:
-            return self.environments.index(row['environment'])
+            return self.as_datatype.index(row['environment'])
 
         return _sorter
 
@@ -49,7 +49,7 @@ class FacetFinder:
             data_type=data_type,
         )
 
-        rows = [row for row in rows if row['environment'] in self.environments]
+        rows = [row for row in rows if row['environment'] in self.as_datatype]
 
         return sorted(
             rows,
@@ -78,7 +78,7 @@ class FacetFinder:
             prefix=URIRef(f'{scheme}:'),
         )
 
-        rows = [row for row in rows if row['environment'] in self.environments]
+        rows = [row for row in rows if row['environment'] in self.as_datatype]
 
         return sorted(
             rows,
@@ -101,7 +101,7 @@ class FacetFinder:
         )
 
         # FIXME This is probably suboptimal, why don't we use `IN environments`?
-        rows = [row for row in rows if row['environment'] in self.environments]
+        rows = [row for row in rows if row['environment'] in self.as_datatype]
 
         return sorted(
             rows,
@@ -120,7 +120,7 @@ class FacetFinder:
             node=self.node,
         )
 
-        rows = [row for row in rows if row['environment'] in self.environments]
+        rows = [row for row in rows if row['environment'] in self.as_datatype]
 
         return sorted(
             rows,
@@ -137,7 +137,7 @@ class FacetFinder:
         triples = [
             triple
             for triple in triples
-            if funcy.first(triple) in self.environments
+            if funcy.first(triple) in self.as_datatype
         ]
 
         rows = [
@@ -168,6 +168,6 @@ class FacetFinder:
 
         raise FacetNotFound(
             node=self.node,
-            as_datatype=self.environments,
+            as_datatype=self.as_datatype,
             node_types=[],
         )

--- a/iolanta/facets/locator.py
+++ b/iolanta/facets/locator.py
@@ -168,6 +168,6 @@ class FacetFinder:
 
         raise FacetNotFound(
             node=self.node,
-            environments=self.environments,
+            as_datatype=self.environments,
             node_types=[],
         )

--- a/iolanta/facets/locator.py
+++ b/iolanta/facets/locator.py
@@ -23,12 +23,12 @@ class FacetFinder:
 
     iolanta: 'iolanta.Iolanta'    # type: ignore
     node: Node
-    as_datatype: List[NotLiteralNode]
+    as_datatype: NotLiteralNode
 
     @cached_property
     def row_sorter_by_environment(self):
         def _sorter(row) -> int:
-            return self.as_datatype.index(row['environment'])
+            return 0
 
         return _sorter
 
@@ -49,7 +49,7 @@ class FacetFinder:
             data_type=data_type,
         )
 
-        rows = [row for row in rows if row['environment'] in self.as_datatype]
+        rows = [row for row in rows if row['environment'] == self.as_datatype]
 
         return sorted(
             rows,
@@ -78,7 +78,7 @@ class FacetFinder:
             prefix=URIRef(f'{scheme}:'),
         )
 
-        rows = [row for row in rows if row['environment'] in self.as_datatype]
+        rows = [row for row in rows if row['environment'] == self.as_datatype]
 
         return sorted(
             rows,
@@ -101,7 +101,7 @@ class FacetFinder:
         )
 
         # FIXME This is probably suboptimal, why don't we use `IN environments`?
-        rows = [row for row in rows if row['environment'] in self.as_datatype]
+        rows = [row for row in rows if row['environment'] == self.as_datatype]
 
         return sorted(
             rows,
@@ -120,7 +120,7 @@ class FacetFinder:
             node=self.node,
         )
 
-        rows = [row for row in rows if row['environment'] in self.as_datatype]
+        rows = [row for row in rows if row['environment'] == self.as_datatype]
 
         return sorted(
             rows,
@@ -137,7 +137,7 @@ class FacetFinder:
         triples = [
             triple
             for triple in triples
-            if funcy.first(triple) in self.as_datatype
+            if funcy.first(triple) == self.as_datatype
         ]
 
         rows = [

--- a/iolanta/facets/page_title.py
+++ b/iolanta/facets/page_title.py
@@ -33,7 +33,7 @@ class PageTitle(Static):
         """Render the title via Iolanta in a thread."""
         return self.iolanta.render(
             self.iri,
-            environments=[URIRef('https://iolanta.tech/env/title')],
+            as_datatype=[URIRef('https://iolanta.tech/env/title')],
         )[0]
 
     def on_mount(self):

--- a/iolanta/facets/page_title.py
+++ b/iolanta/facets/page_title.py
@@ -33,7 +33,7 @@ class PageTitle(Static):
         """Render the title via Iolanta in a thread."""
         return self.iolanta.render(
             self.iri,
-            as_datatype=[URIRef('https://iolanta.tech/env/title')],
+            as_datatype=URIRef('https://iolanta.tech/env/title'),
         )[0]
 
     def on_mount(self):

--- a/iolanta/facets/textual_browser/app.py
+++ b/iolanta/facets/textual_browser/app.py
@@ -130,7 +130,7 @@ class IolantaBrowser(App):   # noqa: WPS214, WPS230
         if not choices:
             raise FacetNotFound(
                 node=self.iri,
-                environments=environments,
+                as_datatype=environments,
                 node_types=[],
             )
 

--- a/iolanta/facets/textual_browser/app.py
+++ b/iolanta/facets/textual_browser/app.py
@@ -149,7 +149,7 @@ class IolantaBrowser(App):   # noqa: WPS214, WPS230
                 title=self.app.call_from_thread(
                     self.iolanta.render,
                     facet,
-                    environments=[URIRef('https://iolanta.tech/env/title')],
+                    as_datatype=[URIRef('https://iolanta.tech/env/title')],
                 )[0],
             )
             for facet in other_facets

--- a/iolanta/facets/textual_browser/app.py
+++ b/iolanta/facets/textual_browser/app.py
@@ -149,7 +149,7 @@ class IolantaBrowser(App):   # noqa: WPS214, WPS230
                 title=self.app.call_from_thread(
                     self.iolanta.render,
                     facet,
-                    as_datatype=[URIRef('https://iolanta.tech/env/title')],
+                    as_datatype=URIRef('https://iolanta.tech/env/title'),
                 )[0],
             )
             for facet in other_facets

--- a/iolanta/facets/textual_browser/app.py
+++ b/iolanta/facets/textual_browser/app.py
@@ -118,7 +118,7 @@ class IolantaBrowser(App):   # noqa: WPS214, WPS230
         self.iri = destination
         iolanta: Iolanta = self.iolanta
 
-        environments = [URIRef('https://iolanta.tech/cli/textual')]
+        environments = URIRef('https://iolanta.tech/cli/textual')
         choices = self.app.call_from_thread(
             FacetFinder(
                 iolanta=self.iolanta,

--- a/iolanta/facets/textual_browser/app.py
+++ b/iolanta/facets/textual_browser/app.py
@@ -123,7 +123,7 @@ class IolantaBrowser(App):   # noqa: WPS214, WPS230
             FacetFinder(
                 iolanta=self.iolanta,
                 node=destination,
-                environments=environments,
+                as_datatype=environments,
             ).choices,
         )
 

--- a/iolanta/facets/textual_class/facets.py
+++ b/iolanta/facets/textual_class/facets.py
@@ -103,7 +103,7 @@ class InstancesList(ListView):   # noqa: WPS214
                 instance_item.update,
                 self.app.iolanta.render(
                     instance_item.node,
-                    environments=[URIRef('https://iolanta.tech/env/title')],
+                    as_datatype=[URIRef('https://iolanta.tech/env/title')],
                 )[0],
             )
 

--- a/iolanta/facets/textual_class/facets.py
+++ b/iolanta/facets/textual_class/facets.py
@@ -103,7 +103,7 @@ class InstancesList(ListView):   # noqa: WPS214
                 instance_item.update,
                 self.app.iolanta.render(
                     instance_item.node,
-                    as_datatype=[URIRef('https://iolanta.tech/env/title')],
+                    as_datatype=URIRef('https://iolanta.tech/env/title'),
                 )[0],
             )
 

--- a/iolanta/facets/textual_default/facets.py
+++ b/iolanta/facets/textual_default/facets.py
@@ -68,7 +68,7 @@ class PropertyName(Widget, can_focus=True, inherit_bindings=False):
     def render_title(self):
         """Render title in a separate thread."""
         environment = URIRef('https://iolanta.tech/env/title')
-        return self.app.iolanta.render(self.iri, [environment])[0]
+        return self.app.iolanta.render(self.iri, environment)[0]
 
     def render(self) -> RenderResult:
         """Render node title."""
@@ -486,16 +486,6 @@ class TextualDefaultFacet(Facet[Widget]):   # noqa: WPS214
 
         if self.description:
             yield Label(self.description, id='description')
-
-        sub_facets = list(
-            self.render_all(
-                self.iri,
-                environment=URIRef('https://iolanta.tech/cli/default'),
-            ),
-        )
-
-        if sub_facets:
-            yield from sub_facets
 
     @property
     def instances(self):

--- a/iolanta/facets/textual_default/facets.py
+++ b/iolanta/facets/textual_default/facets.py
@@ -256,7 +256,7 @@ class PropertyValue(Widget, can_focus=True, inherit_bindings=False):
         """Render title in a separate thread."""
         return self.app.iolanta.render(
             self.property_value,
-            environments=[URIRef('https://iolanta.tech/env/title')],
+            as_datatype=[URIRef('https://iolanta.tech/env/title')],
         )[0]
 
     def on_worker_state_changed(self, event: Worker.StateChanged):
@@ -326,7 +326,7 @@ class PropertiesContainer(Vertical):
         for widget in widgets:
             widget.renderable = self.app.iolanta.render(
                 widget.iri,
-                environments=[URIRef('https://iolanta.tech/env/title')],
+                as_datatype=[URIRef('https://iolanta.tech/env/title')],
             )[0]
 
     def on_mount(self):

--- a/iolanta/facets/textual_default/facets.py
+++ b/iolanta/facets/textual_default/facets.py
@@ -256,7 +256,7 @@ class PropertyValue(Widget, can_focus=True, inherit_bindings=False):
         """Render title in a separate thread."""
         return self.app.iolanta.render(
             self.property_value,
-            as_datatype=[URIRef('https://iolanta.tech/env/title')],
+            as_datatype=URIRef('https://iolanta.tech/env/title'),
         )[0]
 
     def on_worker_state_changed(self, event: Worker.StateChanged):
@@ -326,7 +326,7 @@ class PropertiesContainer(Vertical):
         for widget in widgets:
             widget.renderable = self.app.iolanta.render(
                 widget.iri,
-                as_datatype=[URIRef('https://iolanta.tech/env/title')],
+                as_datatype=URIRef('https://iolanta.tech/env/title'),
             )[0]
 
     def on_mount(self):
@@ -502,7 +502,7 @@ class TextualDefaultFacet(Facet[Widget]):   # noqa: WPS214
         """Instances of this class."""
         return self.render(
             self.iri,
-            as_datatype=[URIRef('https://iolanta.tech/cli/default/instances')],
+            as_datatype=URIRef('https://iolanta.tech/cli/default/instances'),
         )
 
     @property
@@ -510,7 +510,7 @@ class TextualDefaultFacet(Facet[Widget]):   # noqa: WPS214
         """Terms of this ontology."""
         return self.render(
             self.iri,
-            as_datatype=[URIRef('https://iolanta.tech/cli/default/terms')],
+            as_datatype=URIRef('https://iolanta.tech/cli/default/terms'),
         )
 
     @property

--- a/iolanta/facets/textual_default/facets.py
+++ b/iolanta/facets/textual_default/facets.py
@@ -502,7 +502,7 @@ class TextualDefaultFacet(Facet[Widget]):   # noqa: WPS214
         """Instances of this class."""
         return self.render(
             self.iri,
-            environments=[URIRef('https://iolanta.tech/cli/default/instances')],
+            as_datatype=[URIRef('https://iolanta.tech/cli/default/instances')],
         )
 
     @property
@@ -510,7 +510,7 @@ class TextualDefaultFacet(Facet[Widget]):   # noqa: WPS214
         """Terms of this ontology."""
         return self.render(
             self.iri,
-            environments=[URIRef('https://iolanta.tech/cli/default/terms')],
+            as_datatype=[URIRef('https://iolanta.tech/cli/default/terms')],
         )
 
     @property

--- a/iolanta/facets/textual_link/facet.py
+++ b/iolanta/facets/textual_link/facet.py
@@ -15,7 +15,7 @@ class TextualLinkFacet(Facet[str | Text]):
 
         label = self.render(
             self.iri,
-            environments=[URIRef('https://iolanta.tech/env/title')],
+            as_datatype=[URIRef('https://iolanta.tech/env/title')],
         )
 
         iri_type = type(self.iri).__name__

--- a/iolanta/facets/textual_link/facet.py
+++ b/iolanta/facets/textual_link/facet.py
@@ -15,7 +15,7 @@ class TextualLinkFacet(Facet[str | Text]):
 
         label = self.render(
             self.iri,
-            as_datatype=[URIRef('https://iolanta.tech/env/title')],
+            as_datatype=URIRef('https://iolanta.tech/env/title'),
         )
 
         iri_type = type(self.iri).__name__

--- a/iolanta/facets/textual_ontology/facets.py
+++ b/iolanta/facets/textual_ontology/facets.py
@@ -83,15 +83,13 @@ class OntologyFacet(Facet[Widget]):
         for group, rows in self.grouped_terms.items():
             group_title = self.render(
                 group,
-                as_datatype=[URIRef('https://iolanta.tech/env/title')],
+                as_datatype=URIRef('https://iolanta.tech/env/title'),
             ) if group is not None else '<Ungrouped>'
 
             rendered_terms = '\n'.join([
                 self.render(
                     row.term,
-                    as_datatype=[
-                        URIRef('https://iolanta.tech/cli/link'),
-                    ],
+                    as_datatype=URIRef('https://iolanta.tech/cli/link'),
                 )
                 for row in rows
             ])

--- a/iolanta/facets/textual_ontology/facets.py
+++ b/iolanta/facets/textual_ontology/facets.py
@@ -83,13 +83,13 @@ class OntologyFacet(Facet[Widget]):
         for group, rows in self.grouped_terms.items():
             group_title = self.render(
                 group,
-                environments=[URIRef('https://iolanta.tech/env/title')],
+                as_datatype=[URIRef('https://iolanta.tech/env/title')],
             ) if group is not None else '<Ungrouped>'
 
             rendered_terms = '\n'.join([
                 self.render(
                     row.term,
-                    environments=[
+                    as_datatype=[
                         URIRef('https://iolanta.tech/cli/link'),
                     ],
                 )

--- a/iolanta/facets/title/facets.py
+++ b/iolanta/facets/title/facets.py
@@ -34,5 +34,5 @@ class TitleFacet(Facet[str]):
 
         return self.render(
             self.iri,
-            environments=[URIRef('https://iolanta.tech/qname')],
+            as_datatype=[URIRef('https://iolanta.tech/qname')],
         )

--- a/iolanta/facets/title/facets.py
+++ b/iolanta/facets/title/facets.py
@@ -34,5 +34,5 @@ class TitleFacet(Facet[str]):
 
         return self.render(
             self.iri,
-            as_datatype=[URIRef('https://iolanta.tech/qname')],
+            as_datatype=URIRef('https://iolanta.tech/qname'),
         )

--- a/iolanta/iolanta.py
+++ b/iolanta/iolanta.py
@@ -192,7 +192,7 @@ class Iolanta:   # noqa: WPS214
     def __post_init__(self):
         self.add_files_from_plugins()
 
-    def string_to_node(self, name: str | Node) -> Node:
+    def string_to_node(self, name: str | Node) -> NotLiteralNode:
         """
         Parse a string into a node identifier.
 
@@ -220,7 +220,7 @@ class Iolanta:   # noqa: WPS214
     def render(
         self,
         node: Node,
-        as_datatype: List[NotLiteralNode],
+        as_datatype: NotLiteralNode,
     ) -> Tuple[Any, Stack]:
         """Find an Iolanta facet for a node and render it."""
         if not as_datatype:
@@ -228,6 +228,9 @@ class Iolanta:   # noqa: WPS214
                 f'Please provide at least one environment '
                 f'to render {node} against.',
             )
+
+        if isinstance(as_datatype, list):
+            raise NotImplementedError('Got a list for as_datatype :(')
 
         found = FacetFinder(
             iolanta=self,
@@ -263,7 +266,7 @@ class Iolanta:   # noqa: WPS214
             FacetFinder(
                 iolanta=self,
                 node=node,
-                as_datatype=[environment],
+                as_datatype=environment,
             ).choices(),
         )
 

--- a/iolanta/iolanta.py
+++ b/iolanta/iolanta.py
@@ -220,10 +220,10 @@ class Iolanta:   # noqa: WPS214
     def render(
         self,
         node: Node,
-        environments: List[NotLiteralNode],
+        as_datatype: List[NotLiteralNode],
     ) -> Tuple[Any, Stack]:
         """Find an Iolanta facet for a node and render it."""
-        if not environments:
+        if not as_datatype:
             raise ValueError(
                 f'Please provide at least one environment '
                 f'to render {node} against.',
@@ -232,7 +232,7 @@ class Iolanta:   # noqa: WPS214
         found = FacetFinder(
             iolanta=self,
             node=node,
-            environments=environments,
+            environments=as_datatype,
         ).facet_and_environment
 
         facet_class = self.facet_resolver[found['facet']]

--- a/iolanta/iolanta.py
+++ b/iolanta/iolanta.py
@@ -232,7 +232,7 @@ class Iolanta:   # noqa: WPS214
         found = FacetFinder(
             iolanta=self,
             node=node,
-            environments=as_datatype,
+            as_datatype=as_datatype,
         ).facet_and_environment
 
         facet_class = self.facet_resolver[found['facet']]
@@ -263,7 +263,7 @@ class Iolanta:   # noqa: WPS214
             FacetFinder(
                 iolanta=self,
                 node=node,
-                environments=[environment],
+                as_datatype=[environment],
             ).choices(),
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ class FooFacet(Facet[str]):
     def show(self) -> str:
         return self.render(
             Literal('foo'),
-            as_datatype=[IOLANTA.html],
+            as_datatype=IOLANTA.html,
         )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ class FooFacet(Facet[str]):
     def show(self) -> str:
         return self.render(
             Literal('foo'),
-            environments=[IOLANTA.html],
+            as_datatype=[IOLANTA.html],
         )
 
 

--- a/tests/facets/test_bool.py
+++ b/tests/facets/test_bool.py
@@ -18,5 +18,5 @@ def test_bool(
 ):
     assert Iolanta().render(
         Literal(literal, datatype=XSD.boolean),
-        as_datatype=[environment],
+        as_datatype=environment,
     )[0] == icon

--- a/tests/facets/test_bool.py
+++ b/tests/facets/test_bool.py
@@ -18,5 +18,5 @@ def test_bool(
 ):
     assert Iolanta().render(
         Literal(literal, datatype=XSD.boolean),
-        environments=[environment],
+        as_datatype=[environment],
     )[0] == icon

--- a/tests/facets/test_default.py
+++ b/tests/facets/test_default.py
@@ -82,21 +82,21 @@ def node() -> URIRef:
 def test_fallback(node: URIRef, environment: URIRef):
     assert Iolanta().render(
         node=node,
-        as_datatype=[environment],
+        as_datatype=environment,
     )[0] == 'Test'
 
 
 def test_label(with_label, node: URIRef, environment: URIRef, label: str):
     assert Iolanta().add(with_label).render(
         node=node,
-        as_datatype=[environment],
+        as_datatype=environment,
     )[0] == label
 
 
 def test_label_and_icon(with_label_and_icon, node: URIRef, environment: URIRef, label: str):
     assert Iolanta().add(with_label_and_icon).render(
         node=node,
-        as_datatype=[environment],
+        as_datatype=environment,
     )[0] == '⇔ Bazinga'
 
 
@@ -113,7 +113,7 @@ def test_label_and_html_icon(
     assert str(
         Iolanta().add(with_label_and_html_icon).render(
             node=node,
-            as_datatype=[environment],
+            as_datatype=environment,
         )[0],
     ) == '<span title="foo"><span>⇔</span> Bazinga</span>'
 
@@ -127,7 +127,7 @@ def test_html_comment(
 ):
     assert Iolanta().add(with_label_and_comment).render(
         node=node,
-        as_datatype=[html],
+        as_datatype=html,
     )[0].render() == span(label, title=comment).render()
 
 
@@ -140,7 +140,7 @@ def test_html_url(
 ):
     assert Iolanta().add(with_url).render(
         node=node,
-        as_datatype=[html],
+        as_datatype=html,
     )[0].render() == a(
         label,
         href=url,
@@ -156,5 +156,5 @@ def test_cli_url(
 ):
     assert Iolanta().add(with_url).render(
         node=node,
-        as_datatype=[cli],
+        as_datatype=cli,
     )[0] == Text(label, style=Style(link=url))

--- a/tests/facets/test_default.py
+++ b/tests/facets/test_default.py
@@ -82,21 +82,21 @@ def node() -> URIRef:
 def test_fallback(node: URIRef, environment: URIRef):
     assert Iolanta().render(
         node=node,
-        environments=[environment],
+        as_datatype=[environment],
     )[0] == 'Test'
 
 
 def test_label(with_label, node: URIRef, environment: URIRef, label: str):
     assert Iolanta().add(with_label).render(
         node=node,
-        environments=[environment],
+        as_datatype=[environment],
     )[0] == label
 
 
 def test_label_and_icon(with_label_and_icon, node: URIRef, environment: URIRef, label: str):
     assert Iolanta().add(with_label_and_icon).render(
         node=node,
-        environments=[environment],
+        as_datatype=[environment],
     )[0] == '⇔ Bazinga'
 
 
@@ -110,10 +110,12 @@ def test_label_and_html_icon(
     if environment == cli:
         pytest.skip('Not applicable to CLI.')
 
-    assert str(Iolanta().add(with_label_and_html_icon).render(
-        node=node,
-        environments=[environment],
-    )[0]) == '<span title="foo"><span>⇔</span> Bazinga</span>'
+    assert str(
+        Iolanta().add(with_label_and_html_icon).render(
+            node=node,
+            as_datatype=[environment],
+        )[0],
+    ) == '<span title="foo"><span>⇔</span> Bazinga</span>'
 
 
 def test_html_comment(
@@ -125,7 +127,7 @@ def test_html_comment(
 ):
     assert Iolanta().add(with_label_and_comment).render(
         node=node,
-        environments=[html],
+        as_datatype=[html],
     )[0].render() == span(label, title=comment).render()
 
 
@@ -138,7 +140,7 @@ def test_html_url(
 ):
     assert Iolanta().add(with_url).render(
         node=node,
-        environments=[html],
+        as_datatype=[html],
     )[0].render() == a(
         label,
         href=url,
@@ -154,5 +156,5 @@ def test_cli_url(
 ):
     assert Iolanta().add(with_url).render(
         node=node,
-        environments=[cli],
+        as_datatype=[cli],
     )[0] == Text(label, style=Style(link=url))

--- a/tests/test_find_facet.py
+++ b/tests/test_find_facet.py
@@ -13,7 +13,7 @@ def test_none(iolanta: Iolanta, env: URIRef):
     with pytest.raises(FacetNotFound):
         iolanta.render(
             LOCAL.boom,
-            environments=[env],
+            as_datatype=[env],
         )
 
 
@@ -26,7 +26,7 @@ def test_direct(iolanta: Iolanta, facet_iri: str, env: URIRef):
         },
     }).render(
         LOCAL.boom,
-        environments=[env],
+        as_datatype=[env],
     )
 
     assert response == 'foo'
@@ -64,7 +64,7 @@ def test_instance_facet(iolanta: Iolanta, facet_iri: str, env: URIRef):
         },
     }).render(
         LOCAL.boom,
-        environments=[env],
+        as_datatype=[env],
     )[0] == 'foo'
 
 
@@ -77,7 +77,7 @@ def test_default_facet(iolanta: Iolanta, facet_iri: str, env: URIRef):
         },
     }).render(
         LOCAL.boom,
-        environments=[env],
+        as_datatype=[env],
     )[0] == 'foo'
 
 
@@ -90,7 +90,7 @@ def test_datatype_facet(iolanta: Iolanta, facet_iri: str, env: URIRef):
         },
     }).render(
         Literal('foo', datatype=XSD.string),
-        environments=[env],
+        as_datatype=[env],
     )[0] == 'foo'
 
 
@@ -98,5 +98,5 @@ def test_null_datatype_facet(iolanta: Iolanta, facet_iri: str, env: URIRef):
     with pytest.raises(FacetNotFound):
         iolanta.render(
             Literal('foo'),
-            environments=[env],
+            as_datatype=[env],
         )

--- a/tests/test_find_facet.py
+++ b/tests/test_find_facet.py
@@ -13,7 +13,7 @@ def test_none(iolanta: Iolanta, env: URIRef):
     with pytest.raises(FacetNotFound):
         iolanta.render(
             LOCAL.boom,
-            as_datatype=[env],
+            as_datatype=env,
         )
 
 
@@ -26,7 +26,7 @@ def test_direct(iolanta: Iolanta, facet_iri: str, env: URIRef):
         },
     }).render(
         LOCAL.boom,
-        as_datatype=[env],
+        as_datatype=env,
     )
 
     assert response == 'foo'
@@ -64,7 +64,7 @@ def test_instance_facet(iolanta: Iolanta, facet_iri: str, env: URIRef):
         },
     }).render(
         LOCAL.boom,
-        as_datatype=[env],
+        as_datatype=env,
     )[0] == 'foo'
 
 
@@ -77,7 +77,7 @@ def test_default_facet(iolanta: Iolanta, facet_iri: str, env: URIRef):
         },
     }).render(
         LOCAL.boom,
-        as_datatype=[env],
+        as_datatype=env,
     )[0] == 'foo'
 
 
@@ -90,7 +90,7 @@ def test_datatype_facet(iolanta: Iolanta, facet_iri: str, env: URIRef):
         },
     }).render(
         Literal('foo', datatype=XSD.string),
-        as_datatype=[env],
+        as_datatype=env,
     )[0] == 'foo'
 
 
@@ -98,5 +98,5 @@ def test_null_datatype_facet(iolanta: Iolanta, facet_iri: str, env: URIRef):
     with pytest.raises(FacetNotFound):
         iolanta.render(
             Literal('foo'),
-            as_datatype=[env],
+            as_datatype=env,
         )

--- a/tests/test_render_label.py
+++ b/tests/test_render_label.py
@@ -6,5 +6,5 @@ from iolanta.iolanta import Iolanta
 def test_render_label():
     Iolanta().render(
         Literal('type'),
-        as_datatype=[URIRef('https://iolanta.tech/cli/link')],
+        as_datatype=URIRef('https://iolanta.tech/cli/link'),
     )

--- a/tests/test_render_label.py
+++ b/tests/test_render_label.py
@@ -6,5 +6,5 @@ from iolanta.iolanta import Iolanta
 def test_render_label():
     Iolanta().render(
         Literal('type'),
-        environments=[URIRef('https://iolanta.tech/cli/link')],
+        as_datatype=[URIRef('https://iolanta.tech/cli/link')],
     )


### PR DESCRIPTION
- Rename `environment` → `as_datatype` argument to `render()`
- `Facet.render(…, as_datatype)`
- `FacetNotFound.as_datatype`
- `FacetFinder.as_datatype`
- No longer crashing
- `as_datatype` does not accept a list
- `FacetNotFound` no longer crashes
- Avoid infinite cycling caused by `Record`
- No longer dying on `rdfs:`
