### PR TITLE
165 use numbers to choose facets instead of ctrl + letters

### DIFF
--- a/iolanta/data/textual-browser.yaml
+++ b/iolanta/data/textual-browser.yaml
@@ -49,6 +49,9 @@
       rdfs:label: Instances
       iolanta:outputs:
         $id: https://iolanta.tech/cli/textual
+      iolanta:is-preferred-over:
+        - $id: python://iolanta.facets.textual_browser.TextualBrowserFacet
+        - $id: python://iolanta.facets.textual_default.InverseProperties
 
   - $id: owl:Ontology
     iolanta:hasInstanceFacet:

--- a/iolanta/facets/textual_browser/page.py
+++ b/iolanta/facets/textual_browser/page.py
@@ -18,12 +18,7 @@ class Page(ScrollableContainer):
         super().__init__(renderable, id=page_id)
         for number, flip_option in enumerate(flip_options, start=1):
             self._bindings.bind(
-                keys={
-                    1: 'ctrl+j',
-                    2: 'ctrl+k',
-                    3: 'ctrl+l',
-                    4: 'ctrl+;',
-                }[number],
+                keys=str(number),
                 description=flip_option.title,
                 action=(
                     f"app.goto('{iri}', '{flip_option.facet_iri}')"

--- a/iolanta/facets/textual_ontology/facets.py
+++ b/iolanta/facets/textual_ontology/facets.py
@@ -109,11 +109,6 @@ class OntologyFacet(Facet[Widget]):
 
     def _stream_columns(self) -> Iterable[str]:
         for group, rows in self.grouped_terms.items():
-            group_title = self.render(
-                group,
-                as_datatype=DATATYPES.title,
-            ) if group is not None else '<Ungrouped>'
-
             rendered_terms = '\n'.join([
                 self.render(
                     row.term,
@@ -122,4 +117,13 @@ class OntologyFacet(Facet[Widget]):
                 for row in rows
             ])
 
-            yield f'[b]{group_title}[/b]\n\n{rendered_terms}'
+            if group is None:
+                yield rendered_terms
+
+            else:
+                group_title = self.render(
+                    group,
+                    as_datatype=DATATYPES.title,
+                )
+
+                yield f'[b]{group_title}[/b]\n\n{rendered_terms}'


### PR DESCRIPTION
- **#165 Instances view is better than Properties if we are a looking at a Class**
- **#165 Remove the `<Ungrouped>` ugly header**
- **#165 Use numbers to flip among facets**
