### PR TITLE
179 implement a title facet for foafperson

### DIFF
--- a/docs/datatypes/fallback-title.md
+++ b/docs/datatypes/fallback-title.md
@@ -1,0 +1,35 @@
+# :material-format-title: Title
+
+<script type="application/ld+json">
+  {
+    "@context": {
+      "rdfs": "https://www.w3.org/2000/01/rdf-schema#",
+      "rdf": "https://www.w3.org/1999/02/22-rdf-syntax-ns#",
+      "xsd": "https://www.w3.org/2001/XMLSchema#",
+      "iolanta": "https://iolanta.tech/",
+      "iolanta:hasDefaultFacet": {
+        "@type": "@id"
+      },
+      "rdfs:subClassOf": {
+        "@type": "@id"
+      }
+    },
+    "@id": "https://iolanta.tech/datatypes/fallback-title",
+    "rdfs:label": "Fallback Title",
+    "rdfs:description": "A short string naming something. Used in links, lists, page titles, property tables, and many other cases. Should be used as fallback in case more fine-tuned implementations using https://iolanta.tech/datatypes/title do not work.",
+    "rdfs:subClassOf": "xsd:string",
+    "@type": "rdfs:Datatype",
+    "iolanta:hasDefaultFacet": "python://iolanta.facets.title.TitleFacet"
+  }
+</script>
+
+A short string naming something. Used in links, lists, page titles, property tables, and many other cases.
+
+!!! warning "This is a fallback datatype"
+    Should be used as fallback in case more fine-tuned implementations using [Title](/datatypes/title/) do not work for this IRI.
+
+| Property | Value |
+| --- | --- |
+| ∈ Instance Of | `rdfs:Datatype` |
+| ⊊ Subclass Of | `xsd:string` |
+| Has default facet | :material-language-python: `iolanta.facets.title.TitleFacet` | 

--- a/docs/datatypes/index.md
+++ b/docs/datatypes/index.md
@@ -14,4 +14,11 @@ hide: [navigation]
 
     A short string naming something. Used in links, lists, page titles, property tables, and many other cases.
 
+
+-   :material-format-title:{ .lg .middle } __[Fallback Title](fallback-title/)__
+
+    ---
+
+    Type that only the default, fallback title facet can output. Used to fallback to the default implementation if a more specialized one does not work.
+
 </div>

--- a/docs/datatypes/title.md
+++ b/docs/datatypes/title.md
@@ -19,14 +19,28 @@
     "rdfs:description": "A short string naming something. Used in links, lists, page titles, property tables, and many other cases.",
     "rdfs:subClassOf": "xsd:string",
     "@type": "rdfs:Datatype",
-    "iolanta:hasDefaultFacet": "python://iolanta.facets.title.TitleFacet"
-  }
+    "iolanta:hasDefaultFacet": "python://iolanta.facets.title.TitleFacet",
+    "@included": {
+        "@id": "foaf:Person",
+        "iolanta:hasInstanceFacet": {
+            "@id": "python://iolanta.facets.foaf_person_title.FOAFPersonTitle",    
+            "iolanta:outputs": "https://iolanta.tech/datatypes/title"    
+        }
+    }
+}
 </script>
 
 A short string naming something. Used in links, lists, page titles, property tables, and many other cases.
 
-| Property | Value |
-| --- | --- |
-| ∈ Instance Of | `rdfs:Datatype` |
-| ⊊ Subclass Of | `xsd:string` |
+| Property           | Value                                                        |
+|-------------------|--------------------------------------------------------------|
+| ∈ Instance Of     | `rdfs:Datatype`                                              |
+| ⊊ Subclass Of     | `xsd:string`                                                 |
 | Has default facet | :material-language-python: `iolanta.facets.title.TitleFacet` | 
+
+
+## Specialized Facets
+
+| Class         | Facet                                                       | Description                                            |
+|---------------|-------------------------------------------------------------|--------------------------------------------------------|
+| `foaf:Person` | `python://iolanta.facets.foaf_person_title.FOAFPersonTitle` | Render name of a person from their first and last name | 

--- a/iolanta/__init__.py
+++ b/iolanta/__init__.py
@@ -1,3 +1,4 @@
 from iolanta.base_plugin import IolantaBase
+from iolanta.facets import Facet
 from iolanta.plugin import Plugin
 from iolanta.shortcuts import as_document

--- a/iolanta/cyberspace/processor.py
+++ b/iolanta/cyberspace/processor.py
@@ -23,9 +23,10 @@ from yaml_ld.document_loaders.content_types import ParserNotFound
 from yaml_ld.errors import NotFound, YAMLLDError
 from yarl import URL
 
+from iolanta.errors import UnresolvedIRI
 from iolanta.models import Triple, TripleWithVariables
 from iolanta.namespaces import DC, DCTERMS, FOAF, IOLANTA, OWL, RDF, RDFS, VANN
-from iolanta.parsers.dict_parser import UnresolvedIRI, parse_quads
+from iolanta.parsers.dict_parser import parse_quads
 
 logger = logging.getLogger(__name__)
 

--- a/iolanta/cyberspace/processor.py
+++ b/iolanta/cyberspace/processor.py
@@ -26,7 +26,7 @@ from yarl import URL
 from iolanta.errors import UnresolvedIRI
 from iolanta.models import Triple, TripleWithVariables
 from iolanta.namespaces import DC, DCTERMS, FOAF, IOLANTA, OWL, RDF, RDFS, VANN
-from iolanta.parsers.dict_parser import parse_quads
+from iolanta.parse_quads import parse_quads
 
 logger = logging.getLogger(__name__)
 

--- a/iolanta/errors.py
+++ b/iolanta/errors.py
@@ -1,7 +1,10 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
+from typing import Optional
 
 from documented import DocumentedError
 from rdflib.term import Node
+
+from iolanta.models import LDContext
 
 
 @dataclass
@@ -26,3 +29,28 @@ class InsufficientDataForRender(DocumentedError):
             )
 
         return hopeless
+
+
+@dataclass
+class UnresolvedIRI(DocumentedError):
+    """
+    An unresolved IRI found.
+
+        IRI: {self.iri}
+        file: {self.file}
+        prefix: {self.prefix}
+
+    Perhaps you forgot to import appropriate context? For example:
+
+    ```yaml
+    "@context":
+        - {self.prefix}: https://example.com/{self.prefix}/
+    ```
+
+    Context: {self.context}
+    """
+
+    iri: str
+    prefix: str
+    file: Optional[str] = None    # noqa: WPS110
+    context: Optional[LDContext] = None

--- a/iolanta/facets/__init__.py
+++ b/iolanta/facets/__init__.py
@@ -1,0 +1,1 @@
+from iolanta.facets.facet import Facet

--- a/iolanta/facets/facet.py
+++ b/iolanta/facets/facet.py
@@ -55,7 +55,7 @@ class Facet(Generic[FacetOutput]):
     def render(
         self,
         node: Union[str, Node],
-        as_datatype: Optional[Union[str, List[NotLiteralNode]]] = None,
+        as_datatype: NotLiteralNode,
     ) -> Any:
         """Shortcut to render something via iolanta."""
         rendered, stack = self.iolanta.render(

--- a/iolanta/facets/foaf_person_title/__init__.py
+++ b/iolanta/facets/foaf_person_title/__init__.py
@@ -1,0 +1,1 @@
+from iolanta.facets.foaf_person_title.facet import FOAFPersonTitle

--- a/iolanta/facets/foaf_person_title/facet.py
+++ b/iolanta/facets/foaf_person_title/facet.py
@@ -1,0 +1,24 @@
+import funcy
+
+from iolanta import Facet
+from iolanta.namespaces import DATATYPES
+
+
+class FOAFPersonTitle(Facet[str]):
+    """Show title for a foaf:Person object."""
+
+    def show(self) -> str:
+        """Render full name of a person."""
+        row = funcy.first(self.stored_query('names.sparql', person=self.iri))
+
+        if row is None:
+            # Render default title.
+            return self.render(
+                self.iri,
+                as_datatype=DATATYPES['fallback-title'],
+            )
+
+        family_name = row['family_name']
+        given_name = row['given_name']
+
+        return f'{given_name} {family_name}'

--- a/iolanta/facets/foaf_person_title/sparql/names.sparql
+++ b/iolanta/facets/foaf_person_title/sparql/names.sparql
@@ -1,0 +1,4 @@
+SELECT * WHERE {
+    $person schema:familyName ?family_name .
+    $person schema:givenName ?given_name .
+}

--- a/iolanta/facets/textual_default/facets.py
+++ b/iolanta/facets/textual_default/facets.py
@@ -133,7 +133,7 @@ class TextualDefaultFacet(Facet[Widget]):   # noqa: WPS214
     def show(self) -> Widget:
         """Render the content."""
         return VerticalScroll(
-            PageTitle(self.iri, extra='[i]& its RDF properties[/i]'),
+            PageTitle(self.iri),
             Static(self.description or ''),
             self.properties,
         )

--- a/iolanta/iolanta.py
+++ b/iolanta/iolanta.py
@@ -229,7 +229,7 @@ class Iolanta:   # noqa: WPS214
             self.graph,
             bind_namespaces='none',
         )
-        self.graph.bind(prefix='local', namespace=LOCAL)
+        self.graph.bind(prefix='local', namespace=namespaces.LOCAL)
         self.graph.bind(prefix='iolanta', namespace=namespaces.IOLANTA)
         self.graph.bind(prefix='rdf', namespace=namespaces.RDF)
         self.graph.bind(prefix='rdfs', namespace=namespaces.RDFS)

--- a/iolanta/iolanta.py
+++ b/iolanta/iolanta.py
@@ -40,7 +40,7 @@ from iolanta.models import (
     TripleTemplate,
 )
 from iolanta.node_to_qname import node_to_qname
-from iolanta.parsers.dict_parser import parse_quads
+from iolanta.parse_quads import parse_quads
 from iolanta.parsers.yaml import YAML
 from iolanta.plugin import Plugin
 from iolanta.resolvers.python_import import PythonImportResolver

--- a/iolanta/iolanta.py
+++ b/iolanta/iolanta.py
@@ -25,6 +25,7 @@ from yaml_ld.errors import YAMLLDError
 from iolanta import entry_points, namespaces
 from iolanta.conversions import path_to_iri
 from iolanta.cyberspace.processor import normalize_term
+from iolanta.errors import UnresolvedIRI
 from iolanta.facets.errors import FacetError
 from iolanta.facets.facet import Facet
 from iolanta.facets.locator import FacetFinder
@@ -38,9 +39,8 @@ from iolanta.models import (
     Triple,
     TripleTemplate,
 )
-from iolanta.namespaces import LOCAL
 from iolanta.node_to_qname import node_to_qname
-from iolanta.parsers.dict_parser import UnresolvedIRI, parse_quads
+from iolanta.parsers.dict_parser import parse_quads
 from iolanta.parsers.yaml import YAML
 from iolanta.plugin import Plugin
 from iolanta.resolvers.python_import import PythonImportResolver
@@ -59,7 +59,7 @@ class Iolanta:   # noqa: WPS214
     graph: ConjunctiveGraph = field(
         default_factory=functools.partial(
             ConjunctiveGraph,
-            identifier=LOCAL.term('_inference'),
+            identifier=namespaces.LOCAL.term('_inference'),
         ),
     )
     force_plugins: List[Type[Plugin]] = field(default_factory=list)

--- a/iolanta/parse_quads.py
+++ b/iolanta/parse_quads.py
@@ -1,0 +1,81 @@
+import dataclasses
+import hashlib
+from typing import Iterable
+
+from rdflib import BNode, Literal, URIRef
+from rdflib.term import Node
+
+from iolanta.models import Quad
+from iolanta.parsers.dict_parser import raise_if_term_is_qname
+from iolanta.parsers.errors import SpaceInProperty
+
+
+def parse_term(   # noqa: C901
+    term,
+    blank_node_prefix,
+) -> Node:
+    """Parse N-Quads term into a Quad."""
+    if term is None:
+        raise SpaceInProperty()
+
+    term_type = term['type']
+    term_value = term['value']
+
+    if term_type == 'IRI':
+        raise_if_term_is_qname(term_value)
+        return URIRef(term_value)
+
+    if term_type == 'literal':
+        language = term.get('language')
+
+        if datatype := term.get('datatype'):
+            datatype = URIRef(datatype)
+
+        if language and datatype:
+            datatype = None
+
+        return Literal(
+            term_value,
+            datatype=datatype,
+            lang=language,
+        )
+
+    if term_type == 'blank node':
+        return BNode(
+            value=term_value.replace('_:', f'{blank_node_prefix}_'),
+        )
+
+    raise ValueError(f'Unknown term: {term}')
+
+
+def parse_quads(
+    quads_document,
+    graph: URIRef,
+    blank_node_prefix: str = '',
+) -> Iterable[Quad]:
+    """Parse an N-Quads output into a Quads stream."""
+    blank_node_prefix = hashlib.md5(  # noqa: S324
+        blank_node_prefix.encode(),
+    ).hexdigest()
+    blank_node_prefix = f'_:{blank_node_prefix}'
+
+    for graph_name, quads in quads_document.items():
+        if graph_name == '@default':
+            graph_name = graph   # noqa: WPS440
+
+        else:
+            graph_name = URIRef(graph_name)
+
+        for quad in quads:
+            try:
+                yield Quad(
+                    subject=parse_term(quad['subject'], blank_node_prefix),
+                    predicate=parse_term(quad['predicate'], blank_node_prefix),
+                    object=parse_term(quad['object'], blank_node_prefix),
+                    graph=graph_name,
+                )
+            except SpaceInProperty as err:
+                raise dataclasses.replace(
+                    err,
+                    iri=graph,
+                )

--- a/iolanta/parse_quads.py
+++ b/iolanta/parse_quads.py
@@ -5,8 +5,8 @@ from typing import Iterable
 from rdflib import BNode, Literal, URIRef
 from rdflib.term import Node
 
+from iolanta.errors import UnresolvedIRI
 from iolanta.models import Quad
-from iolanta.parsers.dict_parser import raise_if_term_is_qname
 from iolanta.parsers.errors import SpaceInProperty
 
 
@@ -79,3 +79,19 @@ def parse_quads(
                     err,
                     iri=graph,
                 )
+
+
+def raise_if_term_is_qname(term_value: str):
+    """Raise an error if a QName is provided instead of a full IRI."""
+    prefix, etc = term_value.split(':', 1)
+
+    if etc.startswith('/'):
+        return
+
+    if prefix in {'local', 'templates', 'urn'}:
+        return
+
+    raise UnresolvedIRI(
+        iri=term_value,
+        prefix=prefix,
+    )

--- a/iolanta/parsers/dict_parser.py
+++ b/iolanta/parsers/dict_parser.py
@@ -13,6 +13,7 @@ from rdflib import BNode, Literal, URIRef
 from rdflib.term import Node
 from yarl import URL
 
+from iolanta.errors import UnresolvedIRI
 from iolanta.loaders import Loader
 from iolanta.models import LDContext, LDDocument, NotLiteralNode, Quad
 from iolanta.namespaces import IOLANTA, LOCAL, RDF
@@ -129,31 +130,6 @@ def assign_key_if_not_present(  # type: ignore
         ]
 
     return document
-
-
-@dataclass
-class UnresolvedIRI(DocumentedError):
-    """
-    An unresolved IRI found.
-
-        IRI: {self.iri}
-        file: {self.file}
-        prefix: {self.prefix}
-
-    Perhaps you forgot to import appropriate context? For example:
-
-    ```yaml
-    "@context":
-        - {self.prefix}: https://example.com/{self.prefix}/
-    ```
-
-    Context: {self.context}
-    """
-
-    iri: str
-    prefix: str
-    file: Optional[str] = None
-    context: Optional[LDContext] = None
 
 
 def raise_if_term_is_qname(term_value: str):

--- a/iolanta/parsers/dict_parser.py
+++ b/iolanta/parsers/dict_parser.py
@@ -138,22 +138,6 @@ def assign_key_if_not_present(  # type: ignore
     return document
 
 
-def raise_if_term_is_qname(term_value: str):
-    """Raise an error if a QName is provided instead of a full IRI."""
-    prefix, etc = term_value.split(':', 1)
-
-    if etc.startswith('/'):
-        return
-
-    if prefix in {'local', 'templates', 'urn'}:
-        return
-
-    raise UnresolvedIRI(
-        iri=term_value,
-        prefix=prefix,
-    )
-
-
 @dataclass
 class ExpandError(DocumentedError):
     """


### PR DESCRIPTION
- **#179 Document Fallback Title output datatype**
- **#179 ➕ `FOAFPersonTitle` facet**
- **#179 Fix `render(…, datatype)` type**
- **#179 `from iolanta import Facet` is the way to go**
- **#179 `UnresolvedIRI` → `iolanta.errors`**
- **#179 ➕ `iolanta.parse_quads`**
- **#179 `raise_if_term_is_qname` → `iolanta.parse_quads`**
- **#179 Remove unnecessary text from Properties page header**
