### PR TITLE
279 httpsgreggkelloggnetfoafttl crashes iolanta

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -47,9 +47,6 @@ graph LR
         rel-alternate("Spec does not show<br/>a rel=alternate link") --> spec-not-ld
         class rel-alternate bug
         
-        gk("https://greggkellogg.net/foaf.ttl<br/>crashes python-yaml-ld") --> spec-not-ld
-        class gk bug
-        
         w3c-license("https://purl.org/NET/rdflicense/W3C1.0.ttl<br/>crashes python-yaml-ld") --> spec-not-ld
         class w3c-license bug
         

--- a/iolanta/cli/main.py
+++ b/iolanta/cli/main.py
@@ -112,7 +112,7 @@ def render_command(   # noqa: WPS231, WPS238, WPS210, C901
 
     try:
         renderable, stack = iolanta.render(
-            node=node,
+            node=URIRef(node),
             as_datatype=URIRef(as_datatype),
         )
 

--- a/iolanta/cyberspace/processor.py
+++ b/iolanta/cyberspace/processor.py
@@ -630,7 +630,7 @@ class GlobalSPARQLProcessor(Processor):  # noqa: WPS338, WPS214
             quads = list(
                 parse_quads(
                     quads_document=ld_rdf,
-                    graph=source,  # type: ignore
+                    graph=source_uri,
                     blank_node_prefix=str(source),
                 ),
             )

--- a/iolanta/iolanta.py
+++ b/iolanta/iolanta.py
@@ -300,9 +300,7 @@ class Iolanta:   # noqa: WPS214
                 self.add(plugin.data_files)
             except Exception as error:
                 self.logger.error(
-                    'Cannot load %s plugin data files: %s',
-                    plugin,
-                    error,
+                    f'Cannot load {plugin} plugin data files: {error}',
                 )
 
     def __post_init__(self):


### PR DESCRIPTION
- **#279 Fix `%s` in plugin data files error message**
- **#279 `graph` is a `URIRef`**
- **#279 `node` is a URIRef**
- **#279 Update roadmap**
