### PR TITLE
173 visualize a table for all subject and object pairs for a property

### DIFF
--- a/docs/blog/2025-03-15.writing-a-nanopublication/assertion.jsonld
+++ b/docs/blog/2025-03-15.writing-a-nanopublication/assertion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "dc": "http://purl.org/dc/terms/",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "fip": "https://w3id.org/fair/fip/terms/",
+    "rdfs:seeAlso": {
+      "@type": "@id"
+    }
+  },
+  "@id": "https://json-ld.github.io/yaml-ld/spec/",
+  "@type": [
+    "owl:NamedIndividual",
+    "fip:Knowledge-representation-language"
+  ],
+  "dc:description": "A set of conventions built on top of YAML, which outlines how to serialize\nLinked Data as YAML based on JSON-LD syntax, semantics, and APIs.\n",
+  "rdfs:label": "YAML-LD"
+}

--- a/docs/blog/2025-03-15.writing-a-nanopublication/mosquito-no-pubinfo.jsonld
+++ b/docs/blog/2025-03-15.writing-a-nanopublication/mosquito-no-pubinfo.jsonld
@@ -1,0 +1,46 @@
+{
+  "@id": "#Head",
+  "@graph": {
+    "@type": "np:Nanopublication",
+    "@id": "#",
+    "np:hasAssertion": {
+      "@id": "#assertion",
+      "@context": {
+        "ex": "http://example.org/"
+      },
+      "@graph": [
+        {
+          "@id": "ex:mosquito",
+          "ex:transmits": {
+            "@id": "ex:malaria"
+          }
+        }
+      ]
+    },
+    "np:hasProvenance": {
+      "@id": "#provenance",
+      "@graph": [
+        {
+          "@id": "#assertion",
+          "prov:hadPrimarySource": {
+            "@id": "http://dx.doi.org/10.3233/ISU-2010-0613"
+          }
+        }
+      ]
+    }
+  },
+  "@context": {
+    "@base": "http://purl.org/nanopub/temp/mynanopub#",
+    "np": "http://www.nanopub.org/nschema#",
+    "npx": "http://purl.org/nanopub/x/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "foaf": "http://xmlns.com/foaf/0.1/",
+    "dct": "http://purl.org/dc/terms/",
+    "prov": "http://www.w3.org/ns/prov#",
+    "pav": "http://purl.org/pav/",
+    "orcid": "https://orcid.org/",
+    "schema": "https://schema.org/"
+  }
+}

--- a/docs/blog/2025-03-15.writing-a-nanopublication/signed.mosquito-no-pubinfo.jsonld
+++ b/docs/blog/2025-03-15.writing-a-nanopublication/signed.mosquito-no-pubinfo.jsonld
@@ -1,0 +1,47 @@
+PREFIX this: <https://w3id.org/np/RASfCSrQn20SBsDXqg6kLHNKxmmvgl6FzsXvrWfw2WlLo>
+PREFIX sub: <https://w3id.org/np/RASfCSrQn20SBsDXqg6kLHNKxmmvgl6FzsXvrWfw2WlLo#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX np: <http://www.nanopub.org/nschema#>
+PREFIX npx: <http://purl.org/nanopub/x/>
+PREFIX dc: <http://purl.org/dc/elements/1.1/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX pav: <http://purl.org/pav/>
+PREFIX schema: <https://schema.org/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX orcid: <https://orcid.org/>
+PREFIX biolink: <https://w3id.org/biolink/vocab/>
+PREFIX infores: <https://w3id.org/biolink/infores/>
+
+GRAPH sub:Head {
+  <https://w3id.org/np/RASfCSrQn20SBsDXqg6kLHNKxmmvgl6FzsXvrWfw2WlLo> a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo.
+}
+
+GRAPH sub:assertion {
+  <http://example.org/mosquito>
+    <http://example.org/transmits> <http://example.org/malaria>.
+}
+
+GRAPH sub:provenance {
+  sub:assertion
+    prov:hadPrimarySource <http://dx.doi.org/10.3233/ISU-2010-0613>.
+}
+
+GRAPH sub:pubinfo {
+  <https://w3id.org/np/RASfCSrQn20SBsDXqg6kLHNKxmmvgl6FzsXvrWfw2WlLo> a npx:ExampleNanopub;
+    dcterms:created "2025-04-12T08:02:28.041Z"^^xsd:dateTime;
+    dcterms:creator orcid:0009-0001-8740-4213.
+
+  sub:sig
+    npx:hasAlgorithm "RSA";
+    npx:hasPublicKey "AAAAB3NzaC1yc2EAAAADAQABAAACAQCn6rJWI3NmhXLeWDIE+uuqZu2tPbDJ9ARhL5DFPmQahm7aFQ2hCtduWhucML5gBj4bQl/+PsG4bcjz2cFQEgEqCiV7WoK6d7zlm+ru3UbOK+8J1Nbd84zvSjtg/SCo4VOxiu2tgMZR1Ys7S+sm/9GB5jBuZUy2GQxQpKiuK+TDfa4vCZyUt7P6FlyTE7ELNsgeJe4Be+V1lFSjEsmArE166zUOYPMdbpar/r23bHRGr98UbfKUsqHJCVc9YWWzuFwL3Nbuj9f9fZi1DjFJsJb0euEb47AMfA3sadWgnDPgaQ18JDMHLVLuwB9isrTNUn+XXGa2kI4papVPdnmntRuJiZ2ijV8V6b50Wd8uqu7Evy6lx97cEDVQPmuf69AhuBxi7jzczNHRy06xnN8uUb2wPxua9vzlfpBAsE+qLfzlMdbaoqUTJRf+WrsSi8/tReCymVgKhkd66Zd5e43oYNmXvtEK7ITFnERh/bOOb9flTa0F+HsfNGHQj25TJ/GGinDvhToYZ+LHHzG1sTAfVfMDoVM8y/a6sU+ELZeoWh3HxXuhn4y2FAD63i10L+94gbZEwOqvqgvr8q60WLa8U1c+hMSpurFCappp31qjAp2blTzJFPpaL5v4E+ZkTu6CTeC4Vo4rErlQBj6zEwbRuB9w+7tFLvsRGs2tXc6StHJIRQ==";
+    npx:hasSignature "Gzyr+ep+HpYjWxq4s6t9fSxuiSLgAu1GfmXUUFPnW54Q7+o7lYjAZDwwPNI1G32w1nA1uvWrVBYkYNG5jPzCuvLkXXY3VAZCsS4lhXitbEZermKxaFd9RR3238nBQly7xymEvFtRAAYWMoJKsQdzXbKGyTQMFVuQpkx8OuAu/RreMyP4UU0til+uSb7rVBtTORj9M/422vWoyUes4WYR5kD+CCSZKl8U6rYNh8u/kbq7Mx5MExUZD0VDPQhhwW2u23dmQUWDAOtF3VvQS589uOIMmOrPZ/TOJswdXKzzcB8oF7Hh25DgODbYU/PswNk/luGkVePn7TFfqUUIIwwDgt9MtXpBuezbVl+zSTu4rL/Scg6tJDlBypxxG9m4VWKT7keh3jsAbNpf5I9WevcCIUeioCpVXzXsx2gQH8uTD3VE9u959+owxuo23go6lztF3rROMCE9gWf7voDvSwZ4bnme1EpG2Fjvi0xP8USQMdTISj0J1FhZ4nUWLkcm075qxxoi0PqSlBdr+ioO8BG04udKDnGYumYBd5FziazhZKV8uX3aiE8e0CH/+2JQBCOG6r7HDPT8KD7E0/SjFO0dSzGMeKOTC6SzmC7EU5JH9uHkzUdph10LQaclKYY4jbFWRD1adqLWv/oHLDkKuzMiwjOwnDqw52mSXb1gfFtu+hU=";
+    npx:hasSignatureTarget <https://w3id.org/np/RASfCSrQn20SBsDXqg6kLHNKxmmvgl6FzsXvrWfw2WlLo>.
+}

--- a/docs/blog/find-facets-by-sparql-templates.md
+++ b/docs/blog/find-facets-by-sparql-templates.md
@@ -1,0 +1,59 @@
+---
+title: Find facets by SPARQL patterns
+$type: ADR
+date: "2025-04-20"
+hide: [toc]
+---
+
+# Find facets by SPARQL patterns
+
+I need to be able to call `PropertyPairsFacet` for each node which appears in a predicate position. The facet will render all subject-object pairs for this property as a table.
+
+=== ":white_check_mark: Decision: Use SPARQL"
+
+    ```yaml
+    $id: python://iolanta.facets.PropertyPairsFacet
+    iolanta:outputs: datatypes:textual
+    iolanta:pattern: ASK { ?subject $this ?object }
+    ```
+
+    ## :fast_forward: Consequences
+    
+    <div class="grid" markdown>
+    <div markdown>
+    ### :heavy_plus_sign: Pro
+    
+    * Simple and clear implementation
+      * No dependency on SHACL processing overhead
+    </div>
+    <div markdown>
+    ### :heavy_minus_sign: Contra
+    * Patterns are not Linked Data
+        * And therefore cannot be easily reused and extended
+        * :bulb: But this can be amended later by support for a RDF based SPARQL serialization
+    </div>
+    </div>
+  
+=== ":x: SHACL"
+
+    Not supported by [SHACL Core](https://www.w3.org/TR/shacl):
+
+    > SHACL Core includes the following kinds of targets: node targets, class-based targets (including implicit class-based targets), subjects-of targets, and objects-of targets.
+
+    There are no `predicates-as` targets, as we can see.
+
+=== ":x: SHACL-SPARQL"
+
+    ```yaml title="Courtesy of ChatGPT"
+    $id: https://example.com/shapes/PredicateNodeShape
+    $type: sh:NodeShape
+    sh:sparql:
+      $type: sh:SPARQLConstraint
+      sh:message: "Node must appear in predicate position."
+      sh:ask: |-
+        ASK {
+          ?subject $this ?object .
+        }
+    ```
+
+    If we have to use SPARQL anyway then I do not see the need to employ SHACL as an intermediate layer wrapping it.

--- a/docs/datatypes/title.md
+++ b/docs/datatypes/title.md
@@ -27,7 +27,7 @@
             "@id": "python://iolanta.facets.foaf_person_title.FOAFPersonTitle",    
             "iolanta:outputs": {
               "@id": "https://iolanta.tech/datatypes/title"    
-            }    
+            }
         }
     }
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,7 +18,19 @@ graph LR
     classDef happiness fill:#080,stroke:#080,stroke-width:1px,font-weight:bold;
     class happiness happiness
     
-    generate-roadmap("Generate this roadmap<br/>from LD") --> happiness
+    ipfs("Render LD from IPFS") --> happiness
+    
+    wasm("First WASM based facet") --> generate-roadmap("Generate this roadmap<br/>from LD") --> roadmap3d("Implement a 3D view<br/>for the roadmap") --> happiness
+    
+    cli-construct("CLI to construct a graph") --> happiness
+    
+    wasm --> 3d("Render LD graph in 3D") --> happiness
+    
+    jeeves-sh("jeeves.sh does not expose LD") --> happiness
+    class jeeves-sh bug
+    
+    yeti-sh("yeti.sh does not expose LD") --> happiness
+    class yeti-sh bug
     
     nanopub-blog-post("Blog post:<br/><strong>Nanopublishing with Iolanta</strong>") --> markdown-nanopub-blog-post("Blog post:<br/><strong>Quick & readable Nanopublications<br/>with Markdown-LD") --> happiness
     
@@ -26,8 +38,9 @@ graph LR
     
     plan-yaml-ld-to-pyld("Start moving stuff:<br/>Python <code>yaml-ld</code> → <code>pyld</code>") --> happiness
     
-    shacl("Choose facets<br/>based on SHACL shapes") --> happiness
+    foaf-title("FOAF Title facet<br/>only reacts on <code>foaf:Person</code> class") --> happiness
     publish-with-mkdocs("Publish LD<br/>@ <code>mkdocs-iolanta</code>") --> happiness
+    class foaf-title bug
     
     tex("Embed an Iolanta visualization into a LaTeX document") --> happiness
     tractatus("Tractatus Logico-Philosophicus → LD") --> happiness
@@ -51,9 +64,10 @@ graph LR
     
     spec-not-ld --> happiness
     
-    subgraph "YAML-LD spec"
-        prefixes-table("Render prefixes as a table") --> spec-not-ld
+    ld-with-facet("LD should accompany facet?") --> facet-and-widget("Merge Facet → Widget?") --> happiness
+    register-widgets("Register Python widgets<br/>for safety") --> happiness
     
+    subgraph "YAML-LD spec"
         spec-not-ld("Spec exposes too little LD")
         class spec-not-ld bug
         

--- a/iolanta/data/textual-browser.yaml
+++ b/iolanta/data/textual-browser.yaml
@@ -10,6 +10,11 @@
   dcterms: https://purl.org/dc/terms/
   xsd: https://www.w3.org/2001/XMLSchema#
 
+  iolanta:outputs:
+    "@type": "@id"
+
+  $: rdfs:label
+
 "@included":
   - $id: iolanta:icon
     rdfs:label: Icon
@@ -107,3 +112,7 @@
   - $id: https://iolanta.tech/qname
     iolanta:hasDefaultFacet:
       $id: python://iolanta.facets.qname.QNameFacet
+
+  - $id: python://iolanta.facets.textual_property_pairs_table.TextualPropertyPairsTableFacet
+    iolanta:outputs: https://iolanta.tech/cli/textual
+    $: Subjects → Objects

--- a/iolanta/facets/facet.py
+++ b/iolanta/facets/facet.py
@@ -21,6 +21,11 @@ class Facet(Generic[FacetOutput]):
     as_datatype: Optional[NotLiteralNode] = None
 
     @property
+    def this(self) -> NotLiteralNode:
+        """This node."""
+        return self.iri
+
+    @property
     def stored_queries_path(self) -> Path:
         """Construct directory for stored queries for this facet."""
         return Path(inspect.getfile(self.__class__)).parent / 'sparql'

--- a/iolanta/facets/textual_property_pairs_table.py
+++ b/iolanta/facets/textual_property_pairs_table.py
@@ -1,0 +1,133 @@
+from collections import defaultdict
+from typing import Iterable
+
+import funcy
+from rdflib import Literal, Node
+from rich.style import Style
+from rich.text import Text
+from textual.containers import Vertical
+from textual.coordinate import Coordinate
+from textual.widgets import DataTable
+
+from iolanta import Facet
+from iolanta.facets.page_title import PageTitle
+from iolanta.models import NotLiteralNode
+from iolanta.namespaces import DATATYPES
+from iolanta.widgets.mixin import IolantaWidgetMixin
+
+PAIRS_QUERY = """
+SELECT ?subject ?object WHERE {
+    ?subject $this ?object .
+} ORDER BY ?subject ?object
+"""
+
+
+class PairsTable(IolantaWidgetMixin, DataTable):
+    """Render subject → object properties as a table with two columns."""
+
+    BINDINGS = [
+        ('enter', 'goto', 'Goto'),
+    ]
+
+    def __init__(self, pairs: Iterable[tuple[NotLiteralNode, Node]]):
+        """Construct."""
+        super().__init__(show_header=False, cell_padding=1)
+        self.pairs = list(pairs)
+
+    def render_human_readable_cells(self):
+        """Replace the cells with their human readable titles."""
+        terms_and_coordinates = sorted(
+            self.node_to_coordinates.items(),
+            key=lambda node_and_coordinates_pair: len(
+                node_and_coordinates_pair[1],
+            ),
+            reverse=True,
+        )
+
+        for term, coordinates in terms_and_coordinates:
+            title = self.iolanta.render(term, as_datatype=DATATYPES.title)
+            for coordinate in coordinates:
+                self.app.call_from_thread(
+                    self.update_cell_at,
+                    coordinate,
+                    value=Text(title, no_wrap=False),
+                    update_width=False,
+                )
+
+    @funcy.cached_property
+    @funcy.post_processing(dict)
+    def coordinate_to_node(self):
+        """Return a mapping of coordinates to their corresponding nodes."""
+        for row_number, (subject, object_term) in enumerate(self.pairs):
+            yield Coordinate(row_number, 0), subject
+            yield Coordinate(row_number, 1), object_term
+
+    @funcy.cached_property
+    def node_to_coordinates(self) -> defaultdict[Node, list[Coordinate]]:
+        """Map node to coordinates where it appears."""
+        node_to_coordinate = [
+            (node, coordinate)
+            for coordinate, node in self.coordinate_to_node.items()
+        ]
+        return funcy.group_values(node_to_coordinate)
+
+    def format_as_loading(self, node: Node) -> Text:
+        """Intermediate version of a value while it is loading."""
+        if isinstance(node, Literal):
+            node_text = f'⌛ {node}'
+        else:
+            node_text = self.iolanta.node_as_qname(node)
+            node_text = f'⌛ {node_text}'
+
+        return Text(
+            node_text,
+            style=Style(dim=True),
+            no_wrap=False,
+        )
+
+    def on_mount(self):
+        """Fill the table and start rendering."""
+        self.add_columns('Subject', 'Object')
+        self.cell_padding = 1
+
+        for subject, object_term in self.pairs:
+            self.add_row(
+                self.format_as_loading(subject),
+                self.format_as_loading(object_term),
+            )
+
+        self.run_worker(
+            self.render_human_readable_cells,
+            thread=True,
+        )
+
+    def action_goto(self):
+        """Navigate to the selected node."""
+        if self.cursor_coordinate:
+            node = self.coordinate_to_node.get(self.cursor_coordinate)
+            if node is not None:
+                self.app.action_goto(node)
+
+
+class TextualPropertyPairsTableFacet(Facet):
+    """Render a table of subject → object pairs for a property."""
+
+    def show(self):
+        """Construct the table."""
+        rows = self.query(
+            PAIRS_QUERY,
+            this=self.this,
+        )
+
+        return Vertical(
+            PageTitle(
+                self.this,
+                extra='— Subjects & Objects connected by this property',
+            ),
+            PairsTable(
+                [
+                    (row['subject'], row['object'])
+                    for row in rows
+                ],
+            ),
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iolanta"
-version = "2.0.1"
+version = "2.0.2"
 description = "Semantic Web browser"
 authors = ["Anatoly Scherbakov <altaisoft@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
- **#173 🧹 Extra spaces in embedded JSON-LD (which is boo anyway)**
- **#173 Update roadmap**
- **#173 Support ASK queries @ Cyberspace SPARQL processor**
- **#173 Inform Iolanta about the existence of Property Pairs Table facet**
- **#173 ➕ `Facet.this` property**
- **#173 ➕ `FacetFinder.by_sparql()` even if hard coded for now**
- **#173 Drafts about nanopublications**
- **#173 ➕ `TextualPropertyPairsTableFacet`**
- **#173 ADR: Use SPARQL templates to find facets for node**
- **#173 Bump version**
