### PR TITLE
mc 2 prototype

### DIFF
--- a/docs/blog/knowledge-graph-assignment/context.yamlld
+++ b/docs/blog/knowledge-graph-assignment/context.yamlld
@@ -9,6 +9,8 @@
   foaf: http://xmlns.com/foaf/0.1/
   schema: https://schema.org/
   vann: http://purl.org/vocab/vann/
+  rdfg: http://www.w3.org/2009/rdfg#
+  xsd: http://www.w3.org/2001/XMLSchema#
 
   $: rdfs:label
 

--- a/docs/blog/knowledge-graph-assignment/mc2/index.md
+++ b/docs/blog/knowledge-graph-assignment/mc2/index.md
@@ -62,6 +62,28 @@ iolanta iolanta://_meta
 
 The triples in this graph record times when each of the other Named Graphs was loaded. This is important because Iolanta has a capability to auto reload a file in the project directory when that file is edited. This metadata store helps keep track of whether each Named Graph is in sync with its source on disk.
 
+The `iolanta:last-loaded-time` property is used to record these timestamps:
+
+<div class="grid" markdown>
+<div markdown>
+
+```yaml title="last-updated-time.yamlld"
+--8<-- "docs/blog/knowledge-graph-assignment/mc2/last-updated-time.yamlld"
+```
+
+</div>
+
+<div markdown>
+
+```shell
+iolanta last-updated-time.yamlld
+```
+
+[![](/screenshots/docs.blog.knowledge-graph-assignment.mc2.last-updated-time.yamlld.svg)](/screenshots/docs.blog.knowledge-graph-assignment.mc2.last-updated-time.yamlld.svg)
+
+</div>
+</div>
+
 ### Space
 
 Iolanta does not provide any special treatment to space-describing ontologies at this moment, but that can be implemented in specialized facets.
@@ -70,7 +92,41 @@ For instance, based on a pair of WGS84 coordinates, an Iolanta facet could gener
 
 ## :material-numeric-3-box: Groups of Entities
 
-...
+Enforcement of OWL rules, such as
+
+* `owl:oneOf`,
+* or `owl:Restriction`,
+
+requires the support of OWL reasoning. Iolanta is designed so that it does not require any inference at all.
+
+We can, however, use Iolanta to visualize these properties themselves. Why not?
+
+<div class="grid" markdown>
+<div markdown>
+
+:material-link-variant: [`owl:oneOf`](http://www.w3.org/2002/07/owl#oneOf)
+
+```shell
+iolanta http://www.w3.org/2002/07/owl#oneOf
+```
+
+[![](/screenshots/www.w3.org.2002.07.owl.oneof.svg)](/screenshots/www.w3.org.2002.07.owl.oneof.svg)
+
+</div>
+
+<div markdown>
+
+:material-link-variant: [`owl:Restriction`](http://www.w3.org/2002/07/owl#Restriction)
+
+```shell
+iolanta http://www.w3.org/2002/07/owl#Restriction
+```
+
+[![](/screenshots/www.w3.org.2002.07.owl.restriction.svg)](/screenshots/www.w3.org.2002.07.owl.restriction.svg)
+
+</div>
+</div>
+
 
 ## :material-numeric-4-box: Graph Queries
 

--- a/docs/blog/knowledge-graph-assignment/mc2/last-updated-time.yamlld
+++ b/docs/blog/knowledge-graph-assignment/mc2/last-updated-time.yamlld
@@ -1,0 +1,40 @@
+"@context":
+  # Use $keywords instead of @keywords in the ontology & data files.
+  # This will allow to avoid extra quotes.
+  "@import": https://json-ld.org/contexts/dollar-convenience.jsonld
+
+  rdfs: http://www.w3.org/2000/01/rdf-schema#
+  owl: http://www.w3.org/2002/07/owl#
+  schema: https://schema.org/
+  rdfg: http://www.w3.org/2009/rdfg#
+  xsd: http://www.w3.org/2001/XMLSchema#
+  iolanta: https://iolanta.tech/
+
+  $: rdfs:label
+
+  domain:
+    "@id": rdfs:domain
+    "@type": "@id"
+
+  range:
+    "@id": rdfs:range
+    "@type": "@id"
+  
+  rdfs:subPropertyOf:
+    "@type": "@id"
+
+$id: iolanta:last-loaded-time
+$type: owl:DatatypeProperty
+
+$: Last Loaded Time
+
+rdfs:subPropertyOf: schema:dateModified
+
+domain: rdfg:Graph
+range: xsd:dateTime
+
+comment: |
+  Records the timestamp when a Named Graph was last loaded into Iolanta's RDF Dataset.
+  This property is used in the `iolanta://_meta` graph to track when each source
+  of Linked Data was loaded, enabling auto-reload functionality for files in the
+  project directory.

--- a/docs/screenshots/_meta..svg
+++ b/docs/screenshots/_meta..svg
@@ -19,178 +19,178 @@
         font-weight: 700;
     }
 
-    .terminal-3276289716-matrix {
+    .terminal-1597978261-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-3276289716-title {
+    .terminal-1597978261-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-3276289716-r1 { fill: #c5c8c6 }
-.terminal-3276289716-r2 { fill: #e0e0e0 }
-.terminal-3276289716-r3 { fill: #94999c }
-.terminal-3276289716-r4 { fill: #121212 }
-.terminal-3276289716-r5 { fill: #ffffff;font-weight: bold }
-.terminal-3276289716-r6 { fill: #000000 }
-.terminal-3276289716-r7 { fill: #ffa62b;font-weight: bold }
-.terminal-3276289716-r8 { fill: #495259 }
+    .terminal-1597978261-r1 { fill: #c5c8c6 }
+.terminal-1597978261-r2 { fill: #e0e0e0 }
+.terminal-1597978261-r3 { fill: #94999c }
+.terminal-1597978261-r4 { fill: #121212 }
+.terminal-1597978261-r5 { fill: #ffffff;font-weight: bold }
+.terminal-1597978261-r6 { fill: #000000 }
+.terminal-1597978261-r7 { fill: #ffa62b;font-weight: bold }
+.terminal-1597978261-r8 { fill: #495259 }
     </style>
 
     <defs>
-    <clipPath id="terminal-3276289716-clip-terminal">
+    <clipPath id="terminal-1597978261-clip-terminal">
       <rect x="0" y="0" width="1377.6" height="828.5999999999999" />
     </clipPath>
-    <clipPath id="terminal-3276289716-line-0">
+    <clipPath id="terminal-1597978261-line-0">
     <rect x="0" y="1.5" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3276289716-line-1">
+<clipPath id="terminal-1597978261-line-1">
     <rect x="0" y="25.9" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3276289716-line-2">
+<clipPath id="terminal-1597978261-line-2">
     <rect x="0" y="50.3" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3276289716-line-3">
+<clipPath id="terminal-1597978261-line-3">
     <rect x="0" y="74.7" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3276289716-line-4">
+<clipPath id="terminal-1597978261-line-4">
     <rect x="0" y="99.1" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3276289716-line-5">
+<clipPath id="terminal-1597978261-line-5">
     <rect x="0" y="123.5" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3276289716-line-6">
+<clipPath id="terminal-1597978261-line-6">
     <rect x="0" y="147.9" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3276289716-line-7">
+<clipPath id="terminal-1597978261-line-7">
     <rect x="0" y="172.3" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3276289716-line-8">
+<clipPath id="terminal-1597978261-line-8">
     <rect x="0" y="196.7" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3276289716-line-9">
+<clipPath id="terminal-1597978261-line-9">
     <rect x="0" y="221.1" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3276289716-line-10">
+<clipPath id="terminal-1597978261-line-10">
     <rect x="0" y="245.5" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3276289716-line-11">
+<clipPath id="terminal-1597978261-line-11">
     <rect x="0" y="269.9" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3276289716-line-12">
+<clipPath id="terminal-1597978261-line-12">
     <rect x="0" y="294.3" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3276289716-line-13">
+<clipPath id="terminal-1597978261-line-13">
     <rect x="0" y="318.7" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3276289716-line-14">
+<clipPath id="terminal-1597978261-line-14">
     <rect x="0" y="343.1" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3276289716-line-15">
+<clipPath id="terminal-1597978261-line-15">
     <rect x="0" y="367.5" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3276289716-line-16">
+<clipPath id="terminal-1597978261-line-16">
     <rect x="0" y="391.9" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3276289716-line-17">
+<clipPath id="terminal-1597978261-line-17">
     <rect x="0" y="416.3" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3276289716-line-18">
+<clipPath id="terminal-1597978261-line-18">
     <rect x="0" y="440.7" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3276289716-line-19">
+<clipPath id="terminal-1597978261-line-19">
     <rect x="0" y="465.1" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3276289716-line-20">
+<clipPath id="terminal-1597978261-line-20">
     <rect x="0" y="489.5" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3276289716-line-21">
+<clipPath id="terminal-1597978261-line-21">
     <rect x="0" y="513.9" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3276289716-line-22">
+<clipPath id="terminal-1597978261-line-22">
     <rect x="0" y="538.3" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3276289716-line-23">
+<clipPath id="terminal-1597978261-line-23">
     <rect x="0" y="562.7" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3276289716-line-24">
+<clipPath id="terminal-1597978261-line-24">
     <rect x="0" y="587.1" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3276289716-line-25">
+<clipPath id="terminal-1597978261-line-25">
     <rect x="0" y="611.5" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3276289716-line-26">
+<clipPath id="terminal-1597978261-line-26">
     <rect x="0" y="635.9" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3276289716-line-27">
+<clipPath id="terminal-1597978261-line-27">
     <rect x="0" y="660.3" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3276289716-line-28">
+<clipPath id="terminal-1597978261-line-28">
     <rect x="0" y="684.7" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3276289716-line-29">
+<clipPath id="terminal-1597978261-line-29">
     <rect x="0" y="709.1" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3276289716-line-30">
+<clipPath id="terminal-1597978261-line-30">
     <rect x="0" y="733.5" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3276289716-line-31">
+<clipPath id="terminal-1597978261-line-31">
     <rect x="0" y="757.9" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3276289716-line-32">
+<clipPath id="terminal-1597978261-line-32">
     <rect x="0" y="782.3" width="1378.6" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1395" height="877.6" rx="8"/><text class="terminal-3276289716-title" fill="#c5c8c6" text-anchor="middle" x="697" y="27">Iolanta</text>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1395" height="877.6" rx="8"/><text class="terminal-1597978261-title" fill="#c5c8c6" text-anchor="middle" x="697" y="27">Iolanta</text>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-3276289716-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-1597978261-clip-terminal)">
     <rect fill="#242f38" x="0" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="12.2" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="24.4" y="1.5" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="85.4" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="97.6" y="1.5" width="427" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="524.6" y="1.5" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="646.6" y="1.5" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="829.6" y="1.5" width="427" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1256.6" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1268.8" y="1.5" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1268.8" y="1.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1366.4" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#483d8b" x="0" y="25.9" width="1354.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="1354.2" y="25.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#483d8b" x="0" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#483d8b" x="12.2" y="50.3" width="341.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#483d8b" x="353.8" y="50.3" width="988.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#483d8b" x="1342" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="1354.2" y="50.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#483d8b" x="0" y="74.7" width="1354.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="1354.2" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="99.1" width="1354.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="1354.2" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b0000" x="24.4" y="123.5" width="488" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="512.4" y="123.5" width="500.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1012.6" y="123.5" width="317.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1329.8" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="1354.2" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b0000" x="24.4" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b0000" x="48.8" y="147.9" width="439.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b0000" x="488" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="512.4" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="536.8" y="147.9" width="451.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="988.2" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1012.6" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1037" y="147.9" width="292.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1329.8" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="1354.2" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b0000" x="24.4" y="172.3" width="488" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="512.4" y="172.3" width="500.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1012.6" y="172.3" width="317.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1329.8" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="1354.2" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="24.4" y="196.7" width="1305.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1329.8" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="1354.2" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff8c00" x="24.4" y="221.1" width="439.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="463.6" y="221.1" width="500.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="963.8" y="221.1" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1329.8" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="1354.2" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff8c00" x="24.4" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff8c00" x="48.8" y="245.5" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff8c00" x="439.2" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="463.6" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="488" y="245.5" width="451.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="939.4" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="963.8" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="988.2" y="245.5" width="317.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1305.4" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1329.8" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="1354.2" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="269.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff8c00" x="24.4" y="269.9" width="439.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="463.6" y="269.9" width="500.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="963.8" y="269.9" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1329.8" y="269.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="1354.2" y="269.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="294.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="24.4" y="294.3" width="1305.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1329.8" y="294.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="1354.2" y="294.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="318.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#008b8b" x="24.4" y="318.7" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="231.8" y="318.7" width="500.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="318.7" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1098" y="318.7" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1329.8" y="318.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="1354.2" y="318.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="343.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#008b8b" x="24.4" y="343.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#008b8b" x="48.8" y="343.1" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#008b8b" x="207.4" y="343.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="231.8" y="343.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="256.2" y="343.1" width="451.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="707.6" y="343.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="343.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="756.4" y="343.1" width="317.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1073.6" y="343.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1098" y="343.1" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1329.8" y="343.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1354.2" y="343.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#008b8b" x="24.4" y="367.5" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="231.8" y="367.5" width="500.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="367.5" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1098" y="367.5" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1329.8" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1354.2" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="391.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="24.4" y="391.9" width="1305.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1329.8" y="391.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1354.2" y="391.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="416.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#b8860b" x="24.4" y="416.3" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="390.4" y="416.3" width="500.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="890.6" y="416.3" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1256.6" y="416.3" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1329.8" y="416.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1354.2" y="416.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="440.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#b8860b" x="24.4" y="440.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#b8860b" x="48.8" y="440.7" width="317.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#b8860b" x="366" y="440.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="390.4" y="440.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="414.8" y="440.7" width="451.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="866.2" y="440.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="890.6" y="440.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="915" y="440.7" width="317.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1232.2" y="440.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1256.6" y="440.7" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1329.8" y="440.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1354.2" y="440.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="465.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#b8860b" x="24.4" y="465.1" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="390.4" y="465.1" width="500.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="890.6" y="465.1" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1256.6" y="465.1" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1329.8" y="465.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1354.2" y="465.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="489.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="24.4" y="489.5" width="1305.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1329.8" y="489.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1354.2" y="489.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="513.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#006400" x="24.4" y="513.9" width="378.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="402.6" y="513.9" width="500.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="902.8" y="513.9" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1268.8" y="513.9" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1329.8" y="513.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1354.2" y="513.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="538.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#006400" x="24.4" y="538.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#006400" x="48.8" y="538.3" width="329.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#006400" x="378.2" y="538.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="402.6" y="538.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="427" y="538.3" width="451.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="878.4" y="538.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="902.8" y="538.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="927.2" y="538.3" width="317.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1244.4" y="538.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1268.8" y="538.3" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1329.8" y="538.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1354.2" y="538.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="562.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#006400" x="24.4" y="562.7" width="378.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="402.6" y="562.7" width="500.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="902.8" y="562.7" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1268.8" y="562.7" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1329.8" y="562.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1354.2" y="562.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="587.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="24.4" y="587.1" width="1305.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1329.8" y="587.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1354.2" y="587.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="611.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#bdb76b" x="24.4" y="611.5" width="463.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="488" y="611.5" width="500.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="988.2" y="611.5" width="341.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1329.8" y="611.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1354.2" y="611.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="635.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#bdb76b" x="24.4" y="635.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#bdb76b" x="48.8" y="635.9" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#bdb76b" x="463.6" y="635.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="488" y="635.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="512.4" y="635.9" width="451.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="963.8" y="635.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="988.2" y="635.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1012.6" y="635.9" width="317.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1329.8" y="635.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1354.2" y="635.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="660.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#bdb76b" x="24.4" y="660.3" width="463.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="488" y="660.3" width="500.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="988.2" y="660.3" width="341.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1329.8" y="660.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1354.2" y="660.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="684.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="24.4" y="684.7" width="1305.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1329.8" y="684.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1354.2" y="684.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="709.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b008b" x="24.4" y="709.1" width="488" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="512.4" y="709.1" width="500.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1012.6" y="709.1" width="317.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1329.8" y="709.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1354.2" y="709.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="733.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b008b" x="24.4" y="733.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b008b" x="48.8" y="733.5" width="439.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b008b" x="488" y="733.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="512.4" y="733.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="536.8" y="733.5" width="451.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="988.2" y="733.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1012.6" y="733.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1037" y="733.5" width="292.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1329.8" y="733.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1354.2" y="733.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="757.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b008b" x="24.4" y="757.9" width="488" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="512.4" y="757.9" width="500.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1012.6" y="757.9" width="317.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1329.8" y="757.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1354.2" y="757.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="782.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="24.4" y="782.3" width="1305.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1329.8" y="782.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1354.2" y="782.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="0" y="806.7" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="48.8" y="806.7" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="170.8" y="806.7" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="231.8" y="806.7" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="329.4" y="806.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="366" y="806.7" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="573.4" y="806.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="610" y="806.7" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="671" y="806.7" width="561.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1232.2" y="806.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1244.4" y="806.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1268.8" y="806.7" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1366.4" y="806.7" width="12.2" height="24.65" shape-rendering="crispEdges"/>
-    <g class="terminal-3276289716-matrix">
-    <text class="terminal-3276289716-r2" x="12.2" y="20" textLength="24.4" clip-path="url(#terminal-3276289716-line-0)">👁️</text><text class="terminal-3276289716-r2" x="524.6" y="20" textLength="122" clip-path="url(#terminal-3276289716-line-0)">Iolanta&#160;—&#160;</text><text class="terminal-3276289716-r3" x="646.6" y="20" textLength="183" clip-path="url(#terminal-3276289716-line-0)">iolanta://_meta</text><text class="terminal-3276289716-r1" x="1378.6" y="20" textLength="12.2" clip-path="url(#terminal-3276289716-line-0)">
-</text><text class="terminal-3276289716-r1" x="1378.6" y="44.4" textLength="12.2" clip-path="url(#terminal-3276289716-line-1)">
-</text><text class="terminal-3276289716-r5" x="12.2" y="68.8" textLength="341.6" clip-path="url(#terminal-3276289716-line-2)">iolanta://_meta&#160;(19&#160;triples)</text><text class="terminal-3276289716-r1" x="1378.6" y="68.8" textLength="12.2" clip-path="url(#terminal-3276289716-line-2)">
-</text><text class="terminal-3276289716-r1" x="1378.6" y="93.2" textLength="12.2" clip-path="url(#terminal-3276289716-line-3)">
-</text><text class="terminal-3276289716-r1" x="1378.6" y="117.6" textLength="12.2" clip-path="url(#terminal-3276289716-line-4)">
-</text><text class="terminal-3276289716-r1" x="1378.6" y="142" textLength="12.2" clip-path="url(#terminal-3276289716-line-5)">
-</text><text class="terminal-3276289716-r2" x="48.8" y="166.4" textLength="439.2" clip-path="url(#terminal-3276289716-line-6)">https://iolanta.tech/cli/interactive</text><text class="terminal-3276289716-r2" x="536.8" y="166.4" textLength="451.4" clip-path="url(#terminal-3276289716-line-6)">https://iolanta.tech/last-loaded-time</text><text class="terminal-3276289716-r2" x="1037" y="166.4" textLength="292.8" clip-path="url(#terminal-3276289716-line-6)">2025-11-15T22:31:46.0190</text><text class="terminal-3276289716-r1" x="1378.6" y="166.4" textLength="12.2" clip-path="url(#terminal-3276289716-line-6)">
-</text><text class="terminal-3276289716-r1" x="1378.6" y="190.8" textLength="12.2" clip-path="url(#terminal-3276289716-line-7)">
-</text><text class="terminal-3276289716-r1" x="1378.6" y="215.2" textLength="12.2" clip-path="url(#terminal-3276289716-line-8)">
-</text><text class="terminal-3276289716-r1" x="1378.6" y="239.6" textLength="12.2" clip-path="url(#terminal-3276289716-line-9)">
-</text><text class="terminal-3276289716-r2" x="48.8" y="264" textLength="390.4" clip-path="url(#terminal-3276289716-line-10)">https://iolanta.tech/cli/textual</text><text class="terminal-3276289716-r2" x="488" y="264" textLength="451.4" clip-path="url(#terminal-3276289716-line-10)">https://iolanta.tech/last-loaded-time</text><text class="terminal-3276289716-r2" x="988.2" y="264" textLength="317.2" clip-path="url(#terminal-3276289716-line-10)">2025-11-15T22:31:46.638124</text><text class="terminal-3276289716-r1" x="1378.6" y="264" textLength="12.2" clip-path="url(#terminal-3276289716-line-10)">
-</text><text class="terminal-3276289716-r1" x="1378.6" y="288.4" textLength="12.2" clip-path="url(#terminal-3276289716-line-11)">
-</text><text class="terminal-3276289716-r1" x="1378.6" y="312.8" textLength="12.2" clip-path="url(#terminal-3276289716-line-12)">
-</text><text class="terminal-3276289716-r6" x="1354.2" y="337.2" textLength="24.4" clip-path="url(#terminal-3276289716-line-13)">▇▇</text><text class="terminal-3276289716-r1" x="1378.6" y="337.2" textLength="12.2" clip-path="url(#terminal-3276289716-line-13)">
-</text><text class="terminal-3276289716-r2" x="48.8" y="361.6" textLength="158.6" clip-path="url(#terminal-3276289716-line-14)">Graph&#160;Triples</text><text class="terminal-3276289716-r2" x="256.2" y="361.6" textLength="451.4" clip-path="url(#terminal-3276289716-line-14)">https://iolanta.tech/last-loaded-time</text><text class="terminal-3276289716-r2" x="756.4" y="361.6" textLength="317.2" clip-path="url(#terminal-3276289716-line-14)">2025-11-15T22:31:47.175360</text><text class="terminal-3276289716-r1" x="1378.6" y="361.6" textLength="12.2" clip-path="url(#terminal-3276289716-line-14)">
-</text><text class="terminal-3276289716-r1" x="1378.6" y="386" textLength="12.2" clip-path="url(#terminal-3276289716-line-15)">
-</text><text class="terminal-3276289716-r1" x="1378.6" y="410.4" textLength="12.2" clip-path="url(#terminal-3276289716-line-16)">
-</text><text class="terminal-3276289716-r1" x="1378.6" y="434.8" textLength="12.2" clip-path="url(#terminal-3276289716-line-17)">
-</text><text class="terminal-3276289716-r2" x="48.8" y="459.2" textLength="317.2" clip-path="url(#terminal-3276289716-line-18)">https://iolanta.tech/facet</text><text class="terminal-3276289716-r2" x="414.8" y="459.2" textLength="451.4" clip-path="url(#terminal-3276289716-line-18)">https://iolanta.tech/last-loaded-time</text><text class="terminal-3276289716-r2" x="915" y="459.2" textLength="317.2" clip-path="url(#terminal-3276289716-line-18)">2025-11-15T22:31:46.080718</text><text class="terminal-3276289716-r1" x="1378.6" y="459.2" textLength="12.2" clip-path="url(#terminal-3276289716-line-18)">
-</text><text class="terminal-3276289716-r1" x="1378.6" y="483.6" textLength="12.2" clip-path="url(#terminal-3276289716-line-19)">
-</text><text class="terminal-3276289716-r1" x="1378.6" y="508" textLength="12.2" clip-path="url(#terminal-3276289716-line-20)">
-</text><text class="terminal-3276289716-r1" x="1378.6" y="532.4" textLength="12.2" clip-path="url(#terminal-3276289716-line-21)">
-</text><text class="terminal-3276289716-r2" x="48.8" y="556.8" textLength="329.4" clip-path="url(#terminal-3276289716-line-22)">https://iolanta.tech/failed</text><text class="terminal-3276289716-r2" x="427" y="556.8" textLength="451.4" clip-path="url(#terminal-3276289716-line-22)">https://iolanta.tech/last-loaded-time</text><text class="terminal-3276289716-r2" x="927.2" y="556.8" textLength="317.2" clip-path="url(#terminal-3276289716-line-22)">2025-11-15T22:31:46.284859</text><text class="terminal-3276289716-r1" x="1378.6" y="556.8" textLength="12.2" clip-path="url(#terminal-3276289716-line-22)">
-</text><text class="terminal-3276289716-r1" x="1378.6" y="581.2" textLength="12.2" clip-path="url(#terminal-3276289716-line-23)">
-</text><text class="terminal-3276289716-r1" x="1378.6" y="605.6" textLength="12.2" clip-path="url(#terminal-3276289716-line-24)">
-</text><text class="terminal-3276289716-r1" x="1378.6" y="630" textLength="12.2" clip-path="url(#terminal-3276289716-line-25)">
-</text><text class="terminal-3276289716-r2" x="48.8" y="654.4" textLength="414.8" clip-path="url(#terminal-3276289716-line-26)">https://iolanta.tech/has-sub-graph</text><text class="terminal-3276289716-r2" x="512.4" y="654.4" textLength="451.4" clip-path="url(#terminal-3276289716-line-26)">https://iolanta.tech/last-loaded-time</text><text class="terminal-3276289716-r2" x="1012.6" y="654.4" textLength="317.2" clip-path="url(#terminal-3276289716-line-26)">2025-11-15T22:31:47.067228</text><text class="terminal-3276289716-r1" x="1378.6" y="654.4" textLength="12.2" clip-path="url(#terminal-3276289716-line-26)">
-</text><text class="terminal-3276289716-r1" x="1378.6" y="678.8" textLength="12.2" clip-path="url(#terminal-3276289716-line-27)">
-</text><text class="terminal-3276289716-r1" x="1378.6" y="703.2" textLength="12.2" clip-path="url(#terminal-3276289716-line-28)">
-</text><text class="terminal-3276289716-r1" x="1378.6" y="727.6" textLength="12.2" clip-path="url(#terminal-3276289716-line-29)">
-</text><text class="terminal-3276289716-r2" x="48.8" y="752" textLength="439.2" clip-path="url(#terminal-3276289716-line-30)">https://iolanta.tech/hasDefaultFacet</text><text class="terminal-3276289716-r2" x="536.8" y="752" textLength="451.4" clip-path="url(#terminal-3276289716-line-30)">https://iolanta.tech/last-loaded-time</text><text class="terminal-3276289716-r2" x="1037" y="752" textLength="292.8" clip-path="url(#terminal-3276289716-line-30)">2025-11-15T22:31:46.3917</text><text class="terminal-3276289716-r1" x="1378.6" y="752" textLength="12.2" clip-path="url(#terminal-3276289716-line-30)">
-</text><text class="terminal-3276289716-r1" x="1378.6" y="776.4" textLength="12.2" clip-path="url(#terminal-3276289716-line-31)">
-</text><text class="terminal-3276289716-r1" x="1378.6" y="800.8" textLength="12.2" clip-path="url(#terminal-3276289716-line-32)">
-</text><text class="terminal-3276289716-r7" x="0" y="825.2" textLength="48.8" clip-path="url(#terminal-3276289716-line-33)">&#160;f5&#160;</text><text class="terminal-3276289716-r2" x="48.8" y="825.2" textLength="109.8" clip-path="url(#terminal-3276289716-line-33)">🔄&#160;Reload&#160;</text><text class="terminal-3276289716-r7" x="170.8" y="825.2" textLength="61" clip-path="url(#terminal-3276289716-line-33)">&#160;f12&#160;</text><text class="terminal-3276289716-r2" x="231.8" y="825.2" textLength="97.6" clip-path="url(#terminal-3276289716-line-33)">Console&#160;</text><text class="terminal-3276289716-r7" x="329.4" y="825.2" textLength="36.6" clip-path="url(#terminal-3276289716-line-33)">&#160;t&#160;</text><text class="terminal-3276289716-r2" x="366" y="825.2" textLength="207.4" clip-path="url(#terminal-3276289716-line-33)">Toggle&#160;Dark&#160;Mode&#160;</text><text class="terminal-3276289716-r7" x="573.4" y="825.2" textLength="36.6" clip-path="url(#terminal-3276289716-line-33)">&#160;q&#160;</text><text class="terminal-3276289716-r2" x="610" y="825.2" textLength="61" clip-path="url(#terminal-3276289716-line-33)">Quit&#160;</text><text class="terminal-3276289716-r8" x="1232.2" y="825.2" textLength="12.2" clip-path="url(#terminal-3276289716-line-33)">▏</text><text class="terminal-3276289716-r7" x="1244.4" y="825.2" textLength="24.4" clip-path="url(#terminal-3276289716-line-33)">^p</text><text class="terminal-3276289716-r2" x="1268.8" y="825.2" textLength="97.6" clip-path="url(#terminal-3276289716-line-33)">&#160;palette</text>
+    <g class="terminal-1597978261-matrix">
+    <text class="terminal-1597978261-r2" x="12.2" y="20" textLength="24.4" clip-path="url(#terminal-1597978261-line-0)">👁️</text><text class="terminal-1597978261-r2" x="524.6" y="20" textLength="122" clip-path="url(#terminal-1597978261-line-0)">Iolanta&#160;—&#160;</text><text class="terminal-1597978261-r3" x="646.6" y="20" textLength="183" clip-path="url(#terminal-1597978261-line-0)">iolanta://_meta</text><text class="terminal-1597978261-r1" x="1378.6" y="20" textLength="12.2" clip-path="url(#terminal-1597978261-line-0)">
+</text><text class="terminal-1597978261-r1" x="1378.6" y="44.4" textLength="12.2" clip-path="url(#terminal-1597978261-line-1)">
+</text><text class="terminal-1597978261-r5" x="12.2" y="68.8" textLength="341.6" clip-path="url(#terminal-1597978261-line-2)">iolanta://_meta&#160;(19&#160;triples)</text><text class="terminal-1597978261-r1" x="1378.6" y="68.8" textLength="12.2" clip-path="url(#terminal-1597978261-line-2)">
+</text><text class="terminal-1597978261-r1" x="1378.6" y="93.2" textLength="12.2" clip-path="url(#terminal-1597978261-line-3)">
+</text><text class="terminal-1597978261-r1" x="1378.6" y="117.6" textLength="12.2" clip-path="url(#terminal-1597978261-line-4)">
+</text><text class="terminal-1597978261-r1" x="1378.6" y="142" textLength="12.2" clip-path="url(#terminal-1597978261-line-5)">
+</text><text class="terminal-1597978261-r2" x="48.8" y="166.4" textLength="439.2" clip-path="url(#terminal-1597978261-line-6)">https://iolanta.tech/cli/interactive</text><text class="terminal-1597978261-r2" x="536.8" y="166.4" textLength="451.4" clip-path="url(#terminal-1597978261-line-6)">https://iolanta.tech/last-loaded-time</text><text class="terminal-1597978261-r2" x="1037" y="166.4" textLength="292.8" clip-path="url(#terminal-1597978261-line-6)">2025-11-17T22:22:24.2087</text><text class="terminal-1597978261-r1" x="1378.6" y="166.4" textLength="12.2" clip-path="url(#terminal-1597978261-line-6)">
+</text><text class="terminal-1597978261-r1" x="1378.6" y="190.8" textLength="12.2" clip-path="url(#terminal-1597978261-line-7)">
+</text><text class="terminal-1597978261-r1" x="1378.6" y="215.2" textLength="12.2" clip-path="url(#terminal-1597978261-line-8)">
+</text><text class="terminal-1597978261-r1" x="1378.6" y="239.6" textLength="12.2" clip-path="url(#terminal-1597978261-line-9)">
+</text><text class="terminal-1597978261-r2" x="48.8" y="264" textLength="390.4" clip-path="url(#terminal-1597978261-line-10)">https://iolanta.tech/cli/textual</text><text class="terminal-1597978261-r2" x="488" y="264" textLength="451.4" clip-path="url(#terminal-1597978261-line-10)">https://iolanta.tech/last-loaded-time</text><text class="terminal-1597978261-r2" x="988.2" y="264" textLength="317.2" clip-path="url(#terminal-1597978261-line-10)">2025-11-17T22:22:24.632235</text><text class="terminal-1597978261-r1" x="1378.6" y="264" textLength="12.2" clip-path="url(#terminal-1597978261-line-10)">
+</text><text class="terminal-1597978261-r1" x="1378.6" y="288.4" textLength="12.2" clip-path="url(#terminal-1597978261-line-11)">
+</text><text class="terminal-1597978261-r1" x="1378.6" y="312.8" textLength="12.2" clip-path="url(#terminal-1597978261-line-12)">
+</text><text class="terminal-1597978261-r6" x="1354.2" y="337.2" textLength="24.4" clip-path="url(#terminal-1597978261-line-13)">▇▇</text><text class="terminal-1597978261-r1" x="1378.6" y="337.2" textLength="12.2" clip-path="url(#terminal-1597978261-line-13)">
+</text><text class="terminal-1597978261-r2" x="48.8" y="361.6" textLength="158.6" clip-path="url(#terminal-1597978261-line-14)">Graph&#160;Triples</text><text class="terminal-1597978261-r2" x="256.2" y="361.6" textLength="451.4" clip-path="url(#terminal-1597978261-line-14)">https://iolanta.tech/last-loaded-time</text><text class="terminal-1597978261-r2" x="756.4" y="361.6" textLength="317.2" clip-path="url(#terminal-1597978261-line-14)">2025-11-17T22:22:25.232126</text><text class="terminal-1597978261-r1" x="1378.6" y="361.6" textLength="12.2" clip-path="url(#terminal-1597978261-line-14)">
+</text><text class="terminal-1597978261-r1" x="1378.6" y="386" textLength="12.2" clip-path="url(#terminal-1597978261-line-15)">
+</text><text class="terminal-1597978261-r1" x="1378.6" y="410.4" textLength="12.2" clip-path="url(#terminal-1597978261-line-16)">
+</text><text class="terminal-1597978261-r1" x="1378.6" y="434.8" textLength="12.2" clip-path="url(#terminal-1597978261-line-17)">
+</text><text class="terminal-1597978261-r2" x="48.8" y="459.2" textLength="317.2" clip-path="url(#terminal-1597978261-line-18)">https://iolanta.tech/facet</text><text class="terminal-1597978261-r2" x="414.8" y="459.2" textLength="451.4" clip-path="url(#terminal-1597978261-line-18)">https://iolanta.tech/last-loaded-time</text><text class="terminal-1597978261-r2" x="915" y="459.2" textLength="317.2" clip-path="url(#terminal-1597978261-line-18)">2025-11-17T22:22:24.291882</text><text class="terminal-1597978261-r1" x="1378.6" y="459.2" textLength="12.2" clip-path="url(#terminal-1597978261-line-18)">
+</text><text class="terminal-1597978261-r1" x="1378.6" y="483.6" textLength="12.2" clip-path="url(#terminal-1597978261-line-19)">
+</text><text class="terminal-1597978261-r1" x="1378.6" y="508" textLength="12.2" clip-path="url(#terminal-1597978261-line-20)">
+</text><text class="terminal-1597978261-r1" x="1378.6" y="532.4" textLength="12.2" clip-path="url(#terminal-1597978261-line-21)">
+</text><text class="terminal-1597978261-r2" x="48.8" y="556.8" textLength="329.4" clip-path="url(#terminal-1597978261-line-22)">https://iolanta.tech/failed</text><text class="terminal-1597978261-r2" x="427" y="556.8" textLength="451.4" clip-path="url(#terminal-1597978261-line-22)">https://iolanta.tech/last-loaded-time</text><text class="terminal-1597978261-r2" x="927.2" y="556.8" textLength="317.2" clip-path="url(#terminal-1597978261-line-22)">2025-11-17T22:22:24.394221</text><text class="terminal-1597978261-r1" x="1378.6" y="556.8" textLength="12.2" clip-path="url(#terminal-1597978261-line-22)">
+</text><text class="terminal-1597978261-r1" x="1378.6" y="581.2" textLength="12.2" clip-path="url(#terminal-1597978261-line-23)">
+</text><text class="terminal-1597978261-r1" x="1378.6" y="605.6" textLength="12.2" clip-path="url(#terminal-1597978261-line-24)">
+</text><text class="terminal-1597978261-r1" x="1378.6" y="630" textLength="12.2" clip-path="url(#terminal-1597978261-line-25)">
+</text><text class="terminal-1597978261-r2" x="48.8" y="654.4" textLength="414.8" clip-path="url(#terminal-1597978261-line-26)">https://iolanta.tech/has-sub-graph</text><text class="terminal-1597978261-r2" x="512.4" y="654.4" textLength="451.4" clip-path="url(#terminal-1597978261-line-26)">https://iolanta.tech/last-loaded-time</text><text class="terminal-1597978261-r2" x="1012.6" y="654.4" textLength="317.2" clip-path="url(#terminal-1597978261-line-26)">2025-11-17T22:22:25.114097</text><text class="terminal-1597978261-r1" x="1378.6" y="654.4" textLength="12.2" clip-path="url(#terminal-1597978261-line-26)">
+</text><text class="terminal-1597978261-r1" x="1378.6" y="678.8" textLength="12.2" clip-path="url(#terminal-1597978261-line-27)">
+</text><text class="terminal-1597978261-r1" x="1378.6" y="703.2" textLength="12.2" clip-path="url(#terminal-1597978261-line-28)">
+</text><text class="terminal-1597978261-r1" x="1378.6" y="727.6" textLength="12.2" clip-path="url(#terminal-1597978261-line-29)">
+</text><text class="terminal-1597978261-r2" x="48.8" y="752" textLength="439.2" clip-path="url(#terminal-1597978261-line-30)">https://iolanta.tech/hasDefaultFacet</text><text class="terminal-1597978261-r2" x="536.8" y="752" textLength="451.4" clip-path="url(#terminal-1597978261-line-30)">https://iolanta.tech/last-loaded-time</text><text class="terminal-1597978261-r2" x="1037" y="752" textLength="292.8" clip-path="url(#terminal-1597978261-line-30)">2025-11-17T22:22:24.4832</text><text class="terminal-1597978261-r1" x="1378.6" y="752" textLength="12.2" clip-path="url(#terminal-1597978261-line-30)">
+</text><text class="terminal-1597978261-r1" x="1378.6" y="776.4" textLength="12.2" clip-path="url(#terminal-1597978261-line-31)">
+</text><text class="terminal-1597978261-r1" x="1378.6" y="800.8" textLength="12.2" clip-path="url(#terminal-1597978261-line-32)">
+</text><text class="terminal-1597978261-r7" x="0" y="825.2" textLength="48.8" clip-path="url(#terminal-1597978261-line-33)">&#160;f5&#160;</text><text class="terminal-1597978261-r2" x="48.8" y="825.2" textLength="109.8" clip-path="url(#terminal-1597978261-line-33)">🔄&#160;Reload&#160;</text><text class="terminal-1597978261-r7" x="170.8" y="825.2" textLength="61" clip-path="url(#terminal-1597978261-line-33)">&#160;f12&#160;</text><text class="terminal-1597978261-r2" x="231.8" y="825.2" textLength="97.6" clip-path="url(#terminal-1597978261-line-33)">Console&#160;</text><text class="terminal-1597978261-r7" x="329.4" y="825.2" textLength="36.6" clip-path="url(#terminal-1597978261-line-33)">&#160;t&#160;</text><text class="terminal-1597978261-r2" x="366" y="825.2" textLength="207.4" clip-path="url(#terminal-1597978261-line-33)">Toggle&#160;Dark&#160;Mode&#160;</text><text class="terminal-1597978261-r7" x="573.4" y="825.2" textLength="36.6" clip-path="url(#terminal-1597978261-line-33)">&#160;q&#160;</text><text class="terminal-1597978261-r2" x="610" y="825.2" textLength="61" clip-path="url(#terminal-1597978261-line-33)">Quit&#160;</text><text class="terminal-1597978261-r8" x="1232.2" y="825.2" textLength="12.2" clip-path="url(#terminal-1597978261-line-33)">▏</text><text class="terminal-1597978261-r7" x="1244.4" y="825.2" textLength="24.4" clip-path="url(#terminal-1597978261-line-33)">^p</text><text class="terminal-1597978261-r2" x="1268.8" y="825.2" textLength="97.6" clip-path="url(#terminal-1597978261-line-33)">&#160;palette</text>
     </g>
     </g>
 </svg>

--- a/docs/screenshots/docs.blog.knowledge-graph-assignment.mc2.last-updated-time.yamlld.svg
+++ b/docs/screenshots/docs.blog.knowledge-graph-assignment.mc2.last-updated-time.yamlld.svg
@@ -1,0 +1,193 @@
+<svg class="rich-terminal" viewBox="0 0 1397 879.5999999999999" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-418088142-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-418088142-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-418088142-r1 { fill: #c5c8c6 }
+.terminal-418088142-r2 { fill: #e0e0e0 }
+.terminal-418088142-r3 { fill: #ffffff;font-weight: bold }
+.terminal-418088142-r4 { fill: #ffa62b;font-weight: bold }
+.terminal-418088142-r5 { fill: #495259 }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-418088142-clip-terminal">
+      <rect x="0" y="0" width="1377.6" height="828.5999999999999" />
+    </clipPath>
+    <clipPath id="terminal-418088142-line-0">
+    <rect x="0" y="1.5" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-418088142-line-1">
+    <rect x="0" y="25.9" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-418088142-line-2">
+    <rect x="0" y="50.3" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-418088142-line-3">
+    <rect x="0" y="74.7" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-418088142-line-4">
+    <rect x="0" y="99.1" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-418088142-line-5">
+    <rect x="0" y="123.5" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-418088142-line-6">
+    <rect x="0" y="147.9" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-418088142-line-7">
+    <rect x="0" y="172.3" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-418088142-line-8">
+    <rect x="0" y="196.7" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-418088142-line-9">
+    <rect x="0" y="221.1" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-418088142-line-10">
+    <rect x="0" y="245.5" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-418088142-line-11">
+    <rect x="0" y="269.9" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-418088142-line-12">
+    <rect x="0" y="294.3" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-418088142-line-13">
+    <rect x="0" y="318.7" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-418088142-line-14">
+    <rect x="0" y="343.1" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-418088142-line-15">
+    <rect x="0" y="367.5" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-418088142-line-16">
+    <rect x="0" y="391.9" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-418088142-line-17">
+    <rect x="0" y="416.3" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-418088142-line-18">
+    <rect x="0" y="440.7" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-418088142-line-19">
+    <rect x="0" y="465.1" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-418088142-line-20">
+    <rect x="0" y="489.5" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-418088142-line-21">
+    <rect x="0" y="513.9" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-418088142-line-22">
+    <rect x="0" y="538.3" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-418088142-line-23">
+    <rect x="0" y="562.7" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-418088142-line-24">
+    <rect x="0" y="587.1" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-418088142-line-25">
+    <rect x="0" y="611.5" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-418088142-line-26">
+    <rect x="0" y="635.9" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-418088142-line-27">
+    <rect x="0" y="660.3" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-418088142-line-28">
+    <rect x="0" y="684.7" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-418088142-line-29">
+    <rect x="0" y="709.1" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-418088142-line-30">
+    <rect x="0" y="733.5" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-418088142-line-31">
+    <rect x="0" y="757.9" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-418088142-line-32">
+    <rect x="0" y="782.3" width="1378.6" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1395" height="877.6" rx="8"/><text class="terminal-418088142-title" fill="#c5c8c6" text-anchor="middle" x="697" y="27">Iolanta</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-418088142-clip-terminal)">
+    <rect fill="#242f38" x="0" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="12.2" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="24.4" y="1.5" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="85.4" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="97.6" y="1.5" width="512.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="610" y="1.5" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="732" y="1.5" width="524.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1256.6" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1268.8" y="1.5" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1268.8" y="1.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1366.4" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#483d8b" x="0" y="25.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#483d8b" x="0" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#483d8b" x="12.2" y="50.3" width="1305.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#483d8b" x="1317.6" y="50.3" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#483d8b" x="1366.4" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#483d8b" x="0" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#483d8b" x="12.2" y="74.7" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#483d8b" x="109.8" y="74.7" width="1256.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#483d8b" x="1366.4" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#483d8b" x="0" y="99.1" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="123.5" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b0000" x="24.4" y="147.9" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="268.4" y="147.9" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff8c00" x="366" y="147.9" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="610" y="147.9" width="744.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1354.2" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b0000" x="24.4" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b0000" x="48.8" y="172.3" width="195.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b0000" x="244" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="268.4" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="292.8" y="172.3" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="341.6" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff8c00" x="366" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff8c00" x="390.4" y="172.3" width="195.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff8c00" x="585.6" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="610" y="172.3" width="744.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1354.2" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b0000" x="24.4" y="196.7" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="268.4" y="196.7" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff8c00" x="366" y="196.7" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="610" y="196.7" width="744.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1354.2" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="24.4" y="221.1" width="1329.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1354.2" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b0000" x="24.4" y="245.5" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#008b8b" x="268.4" y="245.5" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#b8860b" x="390.4" y="245.5" width="463.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="854" y="245.5" width="500.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1354.2" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="269.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b0000" x="24.4" y="269.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b0000" x="48.8" y="269.9" width="195.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b0000" x="244" y="269.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#008b8b" x="268.4" y="269.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#008b8b" x="292.8" y="269.9" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#008b8b" x="366" y="269.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#b8860b" x="390.4" y="269.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#b8860b" x="414.8" y="269.9" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#b8860b" x="829.6" y="269.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="854" y="269.9" width="500.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1354.2" y="269.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="294.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b0000" x="24.4" y="294.3" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#008b8b" x="268.4" y="294.3" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#b8860b" x="390.4" y="294.3" width="463.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="854" y="294.3" width="500.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1354.2" y="294.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="318.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="24.4" y="318.7" width="1329.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1354.2" y="318.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="343.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b0000" x="24.4" y="343.1" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#006400" x="268.4" y="343.1" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="378.2" y="343.1" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="622.2" y="343.1" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1354.2" y="343.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b0000" x="24.4" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b0000" x="48.8" y="367.5" width="195.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b0000" x="244" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#006400" x="268.4" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#006400" x="292.8" y="367.5" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#006400" x="353.8" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="378.2" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="402.6" y="367.5" width="195.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="597.8" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="622.2" y="367.5" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1354.2" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="391.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b0000" x="24.4" y="391.9" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#006400" x="268.4" y="391.9" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="378.2" y="391.9" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="622.2" y="391.9" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1354.2" y="391.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="416.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="24.4" y="416.3" width="1329.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1354.2" y="416.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="440.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b0000" x="24.4" y="440.7" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#bdb76b" x="268.4" y="440.7" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b008b" x="378.2" y="440.7" width="561.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="939.4" y="440.7" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1354.2" y="440.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="465.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b0000" x="24.4" y="465.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b0000" x="48.8" y="465.1" width="195.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b0000" x="244" y="465.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#bdb76b" x="268.4" y="465.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#bdb76b" x="292.8" y="465.1" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#bdb76b" x="353.8" y="465.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b008b" x="378.2" y="465.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b008b" x="402.6" y="465.1" width="512.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b008b" x="915" y="465.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="939.4" y="465.1" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1354.2" y="465.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="489.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b0000" x="24.4" y="489.5" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#bdb76b" x="268.4" y="489.5" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b008b" x="378.2" y="489.5" width="561.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="939.4" y="489.5" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1354.2" y="489.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="513.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="24.4" y="513.9" width="1329.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1354.2" y="513.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="538.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b0000" x="24.4" y="538.3" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#556b2f" x="268.4" y="538.3" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#9932cc" x="475.8" y="538.3" width="195.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="671" y="538.3" width="683.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1354.2" y="538.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="562.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b0000" x="24.4" y="562.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b0000" x="48.8" y="562.7" width="195.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b0000" x="244" y="562.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#556b2f" x="268.4" y="562.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#556b2f" x="292.8" y="562.7" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#556b2f" x="451.4" y="562.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#9932cc" x="475.8" y="562.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#9932cc" x="500.2" y="562.7" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#9932cc" x="646.6" y="562.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="671" y="562.7" width="683.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1354.2" y="562.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="587.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#8b0000" x="24.4" y="587.1" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#556b2f" x="268.4" y="587.1" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#9932cc" x="475.8" y="587.1" width="195.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="671" y="587.1" width="683.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1354.2" y="587.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="611.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="24.4" y="611.5" width="1329.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1354.2" y="611.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="635.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="660.3" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="684.7" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="709.1" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="733.5" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="757.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="782.3" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="0" y="806.7" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="48.8" y="806.7" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="170.8" y="806.7" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="231.8" y="806.7" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="329.4" y="806.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="366" y="806.7" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="573.4" y="806.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="610" y="806.7" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="671" y="806.7" width="561.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1232.2" y="806.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1244.4" y="806.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1268.8" y="806.7" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1366.4" y="806.7" width="12.2" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-418088142-matrix">
+    <text class="terminal-418088142-r2" x="12.2" y="20" textLength="24.4" clip-path="url(#terminal-418088142-line-0)">👁️</text><text class="terminal-418088142-r2" x="610" y="20" textLength="122" clip-path="url(#terminal-418088142-line-0)">Iolanta&#160;—&#160;</text><text class="terminal-418088142-r1" x="1378.6" y="20" textLength="12.2" clip-path="url(#terminal-418088142-line-0)">
+</text><text class="terminal-418088142-r1" x="1378.6" y="44.4" textLength="12.2" clip-path="url(#terminal-418088142-line-1)">
+</text><text class="terminal-418088142-r3" x="12.2" y="68.8" textLength="1305.4" clip-path="url(#terminal-418088142-line-2)">file:///home/anatoly/projects/iolanta/docs/blog/knowledge-graph-assignment/mc2/last-updated-time.yamlld&#160;(5&#160;</text><text class="terminal-418088142-r1" x="1378.6" y="68.8" textLength="12.2" clip-path="url(#terminal-418088142-line-2)">
+</text><text class="terminal-418088142-r3" x="12.2" y="93.2" textLength="97.6" clip-path="url(#terminal-418088142-line-3)">triples)</text><text class="terminal-418088142-r1" x="1378.6" y="93.2" textLength="12.2" clip-path="url(#terminal-418088142-line-3)">
+</text><text class="terminal-418088142-r1" x="1378.6" y="117.6" textLength="12.2" clip-path="url(#terminal-418088142-line-4)">
+</text><text class="terminal-418088142-r1" x="1378.6" y="142" textLength="12.2" clip-path="url(#terminal-418088142-line-5)">
+</text><text class="terminal-418088142-r1" x="1378.6" y="166.4" textLength="12.2" clip-path="url(#terminal-418088142-line-6)">
+</text><text class="terminal-418088142-r2" x="48.8" y="190.8" textLength="195.2" clip-path="url(#terminal-418088142-line-7)">Last&#160;Loaded&#160;Time</text><text class="terminal-418088142-r2" x="292.8" y="190.8" textLength="48.8" clip-path="url(#terminal-418088142-line-7)">type</text><text class="terminal-418088142-r2" x="390.4" y="190.8" textLength="195.2" clip-path="url(#terminal-418088142-line-7)">DatatypeProperty</text><text class="terminal-418088142-r1" x="1378.6" y="190.8" textLength="12.2" clip-path="url(#terminal-418088142-line-7)">
+</text><text class="terminal-418088142-r1" x="1378.6" y="215.2" textLength="12.2" clip-path="url(#terminal-418088142-line-8)">
+</text><text class="terminal-418088142-r1" x="1378.6" y="239.6" textLength="12.2" clip-path="url(#terminal-418088142-line-9)">
+</text><text class="terminal-418088142-r1" x="1378.6" y="264" textLength="12.2" clip-path="url(#terminal-418088142-line-10)">
+</text><text class="terminal-418088142-r2" x="48.8" y="288.4" textLength="195.2" clip-path="url(#terminal-418088142-line-11)">Last&#160;Loaded&#160;Time</text><text class="terminal-418088142-r2" x="292.8" y="288.4" textLength="73.2" clip-path="url(#terminal-418088142-line-11)">domain</text><text class="terminal-418088142-r2" x="414.8" y="288.4" textLength="414.8" clip-path="url(#terminal-418088142-line-11)">https://www.w3.org/2009/rdfg#Graph</text><text class="terminal-418088142-r1" x="1378.6" y="288.4" textLength="12.2" clip-path="url(#terminal-418088142-line-11)">
+</text><text class="terminal-418088142-r1" x="1378.6" y="312.8" textLength="12.2" clip-path="url(#terminal-418088142-line-12)">
+</text><text class="terminal-418088142-r1" x="1378.6" y="337.2" textLength="12.2" clip-path="url(#terminal-418088142-line-13)">
+</text><text class="terminal-418088142-r1" x="1378.6" y="361.6" textLength="12.2" clip-path="url(#terminal-418088142-line-14)">
+</text><text class="terminal-418088142-r2" x="48.8" y="386" textLength="195.2" clip-path="url(#terminal-418088142-line-15)">Last&#160;Loaded&#160;Time</text><text class="terminal-418088142-r2" x="292.8" y="386" textLength="61" clip-path="url(#terminal-418088142-line-15)">label</text><text class="terminal-418088142-r2" x="402.6" y="386" textLength="195.2" clip-path="url(#terminal-418088142-line-15)">Last&#160;Loaded&#160;Time</text><text class="terminal-418088142-r1" x="1378.6" y="386" textLength="12.2" clip-path="url(#terminal-418088142-line-15)">
+</text><text class="terminal-418088142-r1" x="1378.6" y="410.4" textLength="12.2" clip-path="url(#terminal-418088142-line-16)">
+</text><text class="terminal-418088142-r1" x="1378.6" y="434.8" textLength="12.2" clip-path="url(#terminal-418088142-line-17)">
+</text><text class="terminal-418088142-r1" x="1378.6" y="459.2" textLength="12.2" clip-path="url(#terminal-418088142-line-18)">
+</text><text class="terminal-418088142-r2" x="48.8" y="483.6" textLength="195.2" clip-path="url(#terminal-418088142-line-19)">Last&#160;Loaded&#160;Time</text><text class="terminal-418088142-r2" x="292.8" y="483.6" textLength="61" clip-path="url(#terminal-418088142-line-19)">range</text><text class="terminal-418088142-r2" x="402.6" y="483.6" textLength="512.4" clip-path="url(#terminal-418088142-line-19)">https://www.w3.org/2001/XMLSchema#dateTime</text><text class="terminal-418088142-r1" x="1378.6" y="483.6" textLength="12.2" clip-path="url(#terminal-418088142-line-19)">
+</text><text class="terminal-418088142-r1" x="1378.6" y="508" textLength="12.2" clip-path="url(#terminal-418088142-line-20)">
+</text><text class="terminal-418088142-r1" x="1378.6" y="532.4" textLength="12.2" clip-path="url(#terminal-418088142-line-21)">
+</text><text class="terminal-418088142-r1" x="1378.6" y="556.8" textLength="12.2" clip-path="url(#terminal-418088142-line-22)">
+</text><text class="terminal-418088142-r2" x="48.8" y="581.2" textLength="195.2" clip-path="url(#terminal-418088142-line-23)">Last&#160;Loaded&#160;Time</text><text class="terminal-418088142-r2" x="292.8" y="581.2" textLength="158.6" clip-path="url(#terminal-418088142-line-23)">subPropertyOf</text><text class="terminal-418088142-r2" x="500.2" y="581.2" textLength="146.4" clip-path="url(#terminal-418088142-line-23)">dateModified</text><text class="terminal-418088142-r1" x="1378.6" y="581.2" textLength="12.2" clip-path="url(#terminal-418088142-line-23)">
+</text><text class="terminal-418088142-r1" x="1378.6" y="605.6" textLength="12.2" clip-path="url(#terminal-418088142-line-24)">
+</text><text class="terminal-418088142-r1" x="1378.6" y="630" textLength="12.2" clip-path="url(#terminal-418088142-line-25)">
+</text><text class="terminal-418088142-r1" x="1378.6" y="654.4" textLength="12.2" clip-path="url(#terminal-418088142-line-26)">
+</text><text class="terminal-418088142-r1" x="1378.6" y="678.8" textLength="12.2" clip-path="url(#terminal-418088142-line-27)">
+</text><text class="terminal-418088142-r1" x="1378.6" y="703.2" textLength="12.2" clip-path="url(#terminal-418088142-line-28)">
+</text><text class="terminal-418088142-r1" x="1378.6" y="727.6" textLength="12.2" clip-path="url(#terminal-418088142-line-29)">
+</text><text class="terminal-418088142-r1" x="1378.6" y="752" textLength="12.2" clip-path="url(#terminal-418088142-line-30)">
+</text><text class="terminal-418088142-r1" x="1378.6" y="776.4" textLength="12.2" clip-path="url(#terminal-418088142-line-31)">
+</text><text class="terminal-418088142-r1" x="1378.6" y="800.8" textLength="12.2" clip-path="url(#terminal-418088142-line-32)">
+</text><text class="terminal-418088142-r4" x="0" y="825.2" textLength="48.8" clip-path="url(#terminal-418088142-line-33)">&#160;f5&#160;</text><text class="terminal-418088142-r2" x="48.8" y="825.2" textLength="109.8" clip-path="url(#terminal-418088142-line-33)">🔄&#160;Reload&#160;</text><text class="terminal-418088142-r4" x="170.8" y="825.2" textLength="61" clip-path="url(#terminal-418088142-line-33)">&#160;f12&#160;</text><text class="terminal-418088142-r2" x="231.8" y="825.2" textLength="97.6" clip-path="url(#terminal-418088142-line-33)">Console&#160;</text><text class="terminal-418088142-r4" x="329.4" y="825.2" textLength="36.6" clip-path="url(#terminal-418088142-line-33)">&#160;t&#160;</text><text class="terminal-418088142-r2" x="366" y="825.2" textLength="207.4" clip-path="url(#terminal-418088142-line-33)">Toggle&#160;Dark&#160;Mode&#160;</text><text class="terminal-418088142-r4" x="573.4" y="825.2" textLength="36.6" clip-path="url(#terminal-418088142-line-33)">&#160;q&#160;</text><text class="terminal-418088142-r2" x="610" y="825.2" textLength="61" clip-path="url(#terminal-418088142-line-33)">Quit&#160;</text><text class="terminal-418088142-r5" x="1232.2" y="825.2" textLength="12.2" clip-path="url(#terminal-418088142-line-33)">▏</text><text class="terminal-418088142-r4" x="1244.4" y="825.2" textLength="24.4" clip-path="url(#terminal-418088142-line-33)">^p</text><text class="terminal-418088142-r2" x="1268.8" y="825.2" textLength="97.6" clip-path="url(#terminal-418088142-line-33)">&#160;palette</text>
+    </g>
+    </g>
+</svg>

--- a/docs/screenshots/www.w3.org.2002.07.owl.oneof.svg
+++ b/docs/screenshots/www.w3.org.2002.07.owl.oneof.svg
@@ -1,0 +1,194 @@
+<svg class="rich-terminal" viewBox="0 0 1397 879.5999999999999" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-939637893-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-939637893-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-939637893-r1 { fill: #c5c8c6 }
+.terminal-939637893-r2 { fill: #e0e0e0 }
+.terminal-939637893-r3 { fill: #989898 }
+.terminal-939637893-r4 { fill: #ffffff;font-weight: bold }
+.terminal-939637893-r5 { fill: #b0b0b0;font-weight: bold }
+.terminal-939637893-r6 { fill: #515151 }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-939637893-clip-terminal">
+      <rect x="0" y="0" width="1377.6" height="828.5999999999999" />
+    </clipPath>
+    <clipPath id="terminal-939637893-line-0">
+    <rect x="0" y="1.5" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-1">
+    <rect x="0" y="25.9" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-2">
+    <rect x="0" y="50.3" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-3">
+    <rect x="0" y="74.7" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-4">
+    <rect x="0" y="99.1" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-5">
+    <rect x="0" y="123.5" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-6">
+    <rect x="0" y="147.9" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-7">
+    <rect x="0" y="172.3" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-8">
+    <rect x="0" y="196.7" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-9">
+    <rect x="0" y="221.1" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-10">
+    <rect x="0" y="245.5" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-11">
+    <rect x="0" y="269.9" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-12">
+    <rect x="0" y="294.3" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-13">
+    <rect x="0" y="318.7" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-14">
+    <rect x="0" y="343.1" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-15">
+    <rect x="0" y="367.5" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-16">
+    <rect x="0" y="391.9" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-17">
+    <rect x="0" y="416.3" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-18">
+    <rect x="0" y="440.7" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-19">
+    <rect x="0" y="465.1" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-20">
+    <rect x="0" y="489.5" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-21">
+    <rect x="0" y="513.9" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-22">
+    <rect x="0" y="538.3" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-23">
+    <rect x="0" y="562.7" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-24">
+    <rect x="0" y="587.1" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-25">
+    <rect x="0" y="611.5" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-26">
+    <rect x="0" y="635.9" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-27">
+    <rect x="0" y="660.3" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-28">
+    <rect x="0" y="684.7" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-29">
+    <rect x="0" y="709.1" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-30">
+    <rect x="0" y="733.5" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-31">
+    <rect x="0" y="757.9" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-32">
+    <rect x="0" y="782.3" width="1378.6" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1395" height="877.6" rx="8"/><text class="terminal-939637893-title" fill="#c5c8c6" text-anchor="middle" x="697" y="27">Iolanta</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-939637893-clip-terminal)">
+    <rect fill="#2d2d2d" x="0" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="12.2" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="24.4" y="1.5" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="85.4" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="97.6" y="1.5" width="292.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="390.4" y="1.5" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="512.4" y="1.5" width="439.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="951.6" y="1.5" width="305" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1256.6" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1268.8" y="1.5" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1268.8" y="1.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1366.4" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#454545" x="0" y="25.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#454545" x="0" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#454545" x="12.2" y="50.3" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#454545" x="73.2" y="50.3" width="1293.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#454545" x="1366.4" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#454545" x="0" y="74.7" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="99.1" width="1220" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1220" y="99.1" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="123.5" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="48.8" y="123.5" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="195.2" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="207.4" y="123.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="305" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="317.2" y="123.5" width="1061.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="147.9" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="207.4" y="147.9" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="317.2" y="147.9" width="1061.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="172.3" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="73.2" y="172.3" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="195.2" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="207.4" y="172.3" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="268.4" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="280.6" y="172.3" width="1098" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="196.7" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="207.4" y="196.7" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="280.6" y="196.7" width="1098" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="221.1" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="134.2" y="221.1" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="195.2" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="207.4" y="221.1" width="378.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="585.6" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="597.8" y="221.1" width="780.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="245.5" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="207.4" y="245.5" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="597.8" y="245.5" width="780.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="269.9" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="61" y="269.9" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="195.2" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="207.4" y="269.9" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="256.2" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="268.4" y="269.9" width="1110.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="294.3" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="207.4" y="294.3" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="268.4" y="294.3" width="1110.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="318.7" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="343.1" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="367.5" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="391.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="416.3" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="440.7" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="465.1" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="489.5" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="513.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="538.3" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="562.7" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="587.1" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="611.5" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="635.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="660.3" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="684.7" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="709.1" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="733.5" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="757.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="782.3" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="0" y="806.7" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="48.8" y="806.7" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="170.8" y="806.7" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="231.8" y="806.7" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="329.4" y="806.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="366" y="806.7" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="573.4" y="806.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="610" y="806.7" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="671" y="806.7" width="561.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1232.2" y="806.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1244.4" y="806.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1268.8" y="806.7" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1366.4" y="806.7" width="12.2" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-939637893-matrix">
+    <text class="terminal-939637893-r2" x="12.2" y="20" textLength="24.4" clip-path="url(#terminal-939637893-line-0)">👁️</text><text class="terminal-939637893-r2" x="390.4" y="20" textLength="122" clip-path="url(#terminal-939637893-line-0)">Iolanta&#160;—&#160;</text><text class="terminal-939637893-r3" x="512.4" y="20" textLength="439.2" clip-path="url(#terminal-939637893-line-0)">https://www.w3.org/2002/07/owl#oneOf</text><text class="terminal-939637893-r1" x="1378.6" y="20" textLength="12.2" clip-path="url(#terminal-939637893-line-0)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="44.4" textLength="12.2" clip-path="url(#terminal-939637893-line-1)">
+</text><text class="terminal-939637893-r4" x="12.2" y="68.8" textLength="61" clip-path="url(#terminal-939637893-line-2)">oneOf</text><text class="terminal-939637893-r1" x="1378.6" y="68.8" textLength="12.2" clip-path="url(#terminal-939637893-line-2)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="93.2" textLength="12.2" clip-path="url(#terminal-939637893-line-3)">
+</text><text class="terminal-939637893-r2" x="0" y="117.6" textLength="1220" clip-path="url(#terminal-939637893-line-4)">The&#160;property&#160;that&#160;determines&#160;the&#160;collection&#160;of&#160;individuals&#160;or&#160;data&#160;values&#160;that&#160;build&#160;an&#160;enumeration.</text><text class="terminal-939637893-r1" x="1378.6" y="117.6" textLength="12.2" clip-path="url(#terminal-939637893-line-4)">
+</text><text class="terminal-939637893-r2" x="0" y="142" textLength="48.8" clip-path="url(#terminal-939637893-line-5)">type</text><text class="terminal-939637893-r2" x="207.4" y="142" textLength="97.6" clip-path="url(#terminal-939637893-line-5)">Property</text><text class="terminal-939637893-r1" x="1378.6" y="142" textLength="12.2" clip-path="url(#terminal-939637893-line-5)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="166.4" textLength="12.2" clip-path="url(#terminal-939637893-line-6)">
+</text><text class="terminal-939637893-r2" x="0" y="190.8" textLength="73.2" clip-path="url(#terminal-939637893-line-7)">domain</text><text class="terminal-939637893-r2" x="207.4" y="190.8" textLength="61" clip-path="url(#terminal-939637893-line-7)">Class</text><text class="terminal-939637893-r1" x="1378.6" y="190.8" textLength="12.2" clip-path="url(#terminal-939637893-line-7)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="215.2" textLength="12.2" clip-path="url(#terminal-939637893-line-8)">
+</text><text class="terminal-939637893-r2" x="0" y="239.6" textLength="134.2" clip-path="url(#terminal-939637893-line-9)">isDefinedBy</text><text class="terminal-939637893-r2" x="207.4" y="239.6" textLength="378.2" clip-path="url(#terminal-939637893-line-9)">https://www.w3.org/2002/07/owl#</text><text class="terminal-939637893-r1" x="1378.6" y="239.6" textLength="12.2" clip-path="url(#terminal-939637893-line-9)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="264" textLength="12.2" clip-path="url(#terminal-939637893-line-10)">
+</text><text class="terminal-939637893-r2" x="0" y="288.4" textLength="61" clip-path="url(#terminal-939637893-line-11)">range</text><text class="terminal-939637893-r2" x="207.4" y="288.4" textLength="48.8" clip-path="url(#terminal-939637893-line-11)">List</text><text class="terminal-939637893-r1" x="1378.6" y="288.4" textLength="12.2" clip-path="url(#terminal-939637893-line-11)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="312.8" textLength="12.2" clip-path="url(#terminal-939637893-line-12)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="337.2" textLength="12.2" clip-path="url(#terminal-939637893-line-13)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="361.6" textLength="12.2" clip-path="url(#terminal-939637893-line-14)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="386" textLength="12.2" clip-path="url(#terminal-939637893-line-15)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="410.4" textLength="12.2" clip-path="url(#terminal-939637893-line-16)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="434.8" textLength="12.2" clip-path="url(#terminal-939637893-line-17)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="459.2" textLength="12.2" clip-path="url(#terminal-939637893-line-18)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="483.6" textLength="12.2" clip-path="url(#terminal-939637893-line-19)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="508" textLength="12.2" clip-path="url(#terminal-939637893-line-20)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="532.4" textLength="12.2" clip-path="url(#terminal-939637893-line-21)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="556.8" textLength="12.2" clip-path="url(#terminal-939637893-line-22)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="581.2" textLength="12.2" clip-path="url(#terminal-939637893-line-23)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="605.6" textLength="12.2" clip-path="url(#terminal-939637893-line-24)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="630" textLength="12.2" clip-path="url(#terminal-939637893-line-25)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="654.4" textLength="12.2" clip-path="url(#terminal-939637893-line-26)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="678.8" textLength="12.2" clip-path="url(#terminal-939637893-line-27)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="703.2" textLength="12.2" clip-path="url(#terminal-939637893-line-28)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="727.6" textLength="12.2" clip-path="url(#terminal-939637893-line-29)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="752" textLength="12.2" clip-path="url(#terminal-939637893-line-30)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="776.4" textLength="12.2" clip-path="url(#terminal-939637893-line-31)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="800.8" textLength="12.2" clip-path="url(#terminal-939637893-line-32)">
+</text><text class="terminal-939637893-r5" x="0" y="825.2" textLength="48.8" clip-path="url(#terminal-939637893-line-33)">&#160;f5&#160;</text><text class="terminal-939637893-r2" x="48.8" y="825.2" textLength="109.8" clip-path="url(#terminal-939637893-line-33)">🔄&#160;Reload&#160;</text><text class="terminal-939637893-r5" x="170.8" y="825.2" textLength="61" clip-path="url(#terminal-939637893-line-33)">&#160;f12&#160;</text><text class="terminal-939637893-r2" x="231.8" y="825.2" textLength="97.6" clip-path="url(#terminal-939637893-line-33)">Console&#160;</text><text class="terminal-939637893-r5" x="329.4" y="825.2" textLength="36.6" clip-path="url(#terminal-939637893-line-33)">&#160;t&#160;</text><text class="terminal-939637893-r2" x="366" y="825.2" textLength="207.4" clip-path="url(#terminal-939637893-line-33)">Toggle&#160;Dark&#160;Mode&#160;</text><text class="terminal-939637893-r5" x="573.4" y="825.2" textLength="36.6" clip-path="url(#terminal-939637893-line-33)">&#160;q&#160;</text><text class="terminal-939637893-r2" x="610" y="825.2" textLength="61" clip-path="url(#terminal-939637893-line-33)">Quit&#160;</text><text class="terminal-939637893-r6" x="1232.2" y="825.2" textLength="12.2" clip-path="url(#terminal-939637893-line-33)">▏</text><text class="terminal-939637893-r5" x="1244.4" y="825.2" textLength="24.4" clip-path="url(#terminal-939637893-line-33)">^p</text><text class="terminal-939637893-r2" x="1268.8" y="825.2" textLength="97.6" clip-path="url(#terminal-939637893-line-33)">&#160;palette</text>
+    </g>
+    </g>
+</svg>

--- a/docs/screenshots/www.w3.org.2002.07.owl.restriction.svg
+++ b/docs/screenshots/www.w3.org.2002.07.owl.restriction.svg
@@ -19,176 +19,176 @@
         font-weight: 700;
     }
 
-    .terminal-2588586139-matrix {
+    .terminal-2068471928-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-2588586139-title {
+    .terminal-2068471928-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-2588586139-r1 { fill: #c5c8c6 }
-.terminal-2588586139-r2 { fill: #e0e0e0 }
-.terminal-2588586139-r3 { fill: #989898 }
-.terminal-2588586139-r4 { fill: #ffffff;font-weight: bold }
-.terminal-2588586139-r5 { fill: #b0b0b0;font-weight: bold }
-.terminal-2588586139-r6 { fill: #515151 }
+    .terminal-2068471928-r1 { fill: #c5c8c6 }
+.terminal-2068471928-r2 { fill: #e0e0e0 }
+.terminal-2068471928-r3 { fill: #989898 }
+.terminal-2068471928-r4 { fill: #ffffff;font-weight: bold }
+.terminal-2068471928-r5 { fill: #b0b0b0;font-weight: bold }
+.terminal-2068471928-r6 { fill: #515151 }
     </style>
 
     <defs>
-    <clipPath id="terminal-2588586139-clip-terminal">
+    <clipPath id="terminal-2068471928-clip-terminal">
       <rect x="0" y="0" width="1377.6" height="828.5999999999999" />
     </clipPath>
-    <clipPath id="terminal-2588586139-line-0">
+    <clipPath id="terminal-2068471928-line-0">
     <rect x="0" y="1.5" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2588586139-line-1">
+<clipPath id="terminal-2068471928-line-1">
     <rect x="0" y="25.9" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2588586139-line-2">
+<clipPath id="terminal-2068471928-line-2">
     <rect x="0" y="50.3" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2588586139-line-3">
+<clipPath id="terminal-2068471928-line-3">
     <rect x="0" y="74.7" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2588586139-line-4">
+<clipPath id="terminal-2068471928-line-4">
     <rect x="0" y="99.1" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2588586139-line-5">
+<clipPath id="terminal-2068471928-line-5">
     <rect x="0" y="123.5" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2588586139-line-6">
+<clipPath id="terminal-2068471928-line-6">
     <rect x="0" y="147.9" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2588586139-line-7">
+<clipPath id="terminal-2068471928-line-7">
     <rect x="0" y="172.3" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2588586139-line-8">
+<clipPath id="terminal-2068471928-line-8">
     <rect x="0" y="196.7" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2588586139-line-9">
+<clipPath id="terminal-2068471928-line-9">
     <rect x="0" y="221.1" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2588586139-line-10">
+<clipPath id="terminal-2068471928-line-10">
     <rect x="0" y="245.5" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2588586139-line-11">
+<clipPath id="terminal-2068471928-line-11">
     <rect x="0" y="269.9" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2588586139-line-12">
+<clipPath id="terminal-2068471928-line-12">
     <rect x="0" y="294.3" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2588586139-line-13">
+<clipPath id="terminal-2068471928-line-13">
     <rect x="0" y="318.7" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2588586139-line-14">
+<clipPath id="terminal-2068471928-line-14">
     <rect x="0" y="343.1" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2588586139-line-15">
+<clipPath id="terminal-2068471928-line-15">
     <rect x="0" y="367.5" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2588586139-line-16">
+<clipPath id="terminal-2068471928-line-16">
     <rect x="0" y="391.9" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2588586139-line-17">
+<clipPath id="terminal-2068471928-line-17">
     <rect x="0" y="416.3" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2588586139-line-18">
+<clipPath id="terminal-2068471928-line-18">
     <rect x="0" y="440.7" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2588586139-line-19">
+<clipPath id="terminal-2068471928-line-19">
     <rect x="0" y="465.1" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2588586139-line-20">
+<clipPath id="terminal-2068471928-line-20">
     <rect x="0" y="489.5" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2588586139-line-21">
+<clipPath id="terminal-2068471928-line-21">
     <rect x="0" y="513.9" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2588586139-line-22">
+<clipPath id="terminal-2068471928-line-22">
     <rect x="0" y="538.3" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2588586139-line-23">
+<clipPath id="terminal-2068471928-line-23">
     <rect x="0" y="562.7" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2588586139-line-24">
+<clipPath id="terminal-2068471928-line-24">
     <rect x="0" y="587.1" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2588586139-line-25">
+<clipPath id="terminal-2068471928-line-25">
     <rect x="0" y="611.5" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2588586139-line-26">
+<clipPath id="terminal-2068471928-line-26">
     <rect x="0" y="635.9" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2588586139-line-27">
+<clipPath id="terminal-2068471928-line-27">
     <rect x="0" y="660.3" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2588586139-line-28">
+<clipPath id="terminal-2068471928-line-28">
     <rect x="0" y="684.7" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2588586139-line-29">
+<clipPath id="terminal-2068471928-line-29">
     <rect x="0" y="709.1" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2588586139-line-30">
+<clipPath id="terminal-2068471928-line-30">
     <rect x="0" y="733.5" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2588586139-line-31">
+<clipPath id="terminal-2068471928-line-31">
     <rect x="0" y="757.9" width="1378.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2588586139-line-32">
+<clipPath id="terminal-2068471928-line-32">
     <rect x="0" y="782.3" width="1378.6" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1395" height="877.6" rx="8"/><text class="terminal-2588586139-title" fill="#c5c8c6" text-anchor="middle" x="697" y="27">Iolanta</text>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1395" height="877.6" rx="8"/><text class="terminal-2068471928-title" fill="#c5c8c6" text-anchor="middle" x="697" y="27">Iolanta</text>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-2588586139-clip-terminal)">
-    <rect fill="#2d2d2d" x="0" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="12.2" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="24.4" y="1.5" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="85.4" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="97.6" y="1.5" width="256.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="353.8" y="1.5" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="475.8" y="1.5" width="512.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="988.2" y="1.5" width="268.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1256.6" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1268.8" y="1.5" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1268.8" y="1.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1366.4" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#454545" x="0" y="25.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#454545" x="0" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#454545" x="12.2" y="50.3" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#454545" x="146.4" y="50.3" width="1220" height="24.65" shape-rendering="crispEdges"/><rect fill="#454545" x="1366.4" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#454545" x="0" y="74.7" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#333333" x="0" y="99.1" width="915" height="24.65" shape-rendering="crispEdges"/><rect fill="#333333" x="915" y="99.1" width="463.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="123.5" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="147.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="172.3" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="196.7" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="221.1" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="245.5" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="269.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="294.3" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="318.7" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="343.1" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="367.5" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="391.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="416.3" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="440.7" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="465.1" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="489.5" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="513.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="538.3" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="562.7" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="587.1" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="611.5" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="635.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="660.3" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="684.7" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="709.1" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="733.5" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="757.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="782.3" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="0" y="806.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="36.6" y="806.7" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="170.8" y="806.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="207.4" y="806.7" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="439.2" y="806.7" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="488" y="806.7" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="610" y="806.7" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="671" y="806.7" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="768.6" y="806.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="805.2" y="806.7" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1012.6" y="806.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1049.2" y="806.7" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1110.2" y="806.7" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1232.2" y="806.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1244.4" y="806.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1268.8" y="806.7" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1366.4" y="806.7" width="12.2" height="24.65" shape-rendering="crispEdges"/>
-    <g class="terminal-2588586139-matrix">
-    <text class="terminal-2588586139-r2" x="12.2" y="20" textLength="24.4" clip-path="url(#terminal-2588586139-line-0)">👁️</text><text class="terminal-2588586139-r2" x="353.8" y="20" textLength="122" clip-path="url(#terminal-2588586139-line-0)">Iolanta&#160;—&#160;</text><text class="terminal-2588586139-r3" x="475.8" y="20" textLength="512.4" clip-path="url(#terminal-2588586139-line-0)">https://www.w3.org/2002/07/owl#Restriction</text><text class="terminal-2588586139-r1" x="1378.6" y="20" textLength="12.2" clip-path="url(#terminal-2588586139-line-0)">
-</text><text class="terminal-2588586139-r1" x="1378.6" y="44.4" textLength="12.2" clip-path="url(#terminal-2588586139-line-1)">
-</text><text class="terminal-2588586139-r4" x="12.2" y="68.8" textLength="134.2" clip-path="url(#terminal-2588586139-line-2)">Restriction</text><text class="terminal-2588586139-r1" x="1378.6" y="68.8" textLength="12.2" clip-path="url(#terminal-2588586139-line-2)">
-</text><text class="terminal-2588586139-r1" x="1378.6" y="93.2" textLength="12.2" clip-path="url(#terminal-2588586139-line-3)">
-</text><text class="terminal-2588586139-r2" x="0" y="117.6" textLength="915" clip-path="url(#terminal-2588586139-line-4)">https://www.w3.org/2009/08/skos-reference/N0856a4a8e1e84fa090f90d2eb2f6df14</text><text class="terminal-2588586139-r1" x="1378.6" y="117.6" textLength="12.2" clip-path="url(#terminal-2588586139-line-4)">
-</text><text class="terminal-2588586139-r1" x="1378.6" y="142" textLength="12.2" clip-path="url(#terminal-2588586139-line-5)">
-</text><text class="terminal-2588586139-r1" x="1378.6" y="166.4" textLength="12.2" clip-path="url(#terminal-2588586139-line-6)">
-</text><text class="terminal-2588586139-r1" x="1378.6" y="190.8" textLength="12.2" clip-path="url(#terminal-2588586139-line-7)">
-</text><text class="terminal-2588586139-r1" x="1378.6" y="215.2" textLength="12.2" clip-path="url(#terminal-2588586139-line-8)">
-</text><text class="terminal-2588586139-r1" x="1378.6" y="239.6" textLength="12.2" clip-path="url(#terminal-2588586139-line-9)">
-</text><text class="terminal-2588586139-r1" x="1378.6" y="264" textLength="12.2" clip-path="url(#terminal-2588586139-line-10)">
-</text><text class="terminal-2588586139-r1" x="1378.6" y="288.4" textLength="12.2" clip-path="url(#terminal-2588586139-line-11)">
-</text><text class="terminal-2588586139-r1" x="1378.6" y="312.8" textLength="12.2" clip-path="url(#terminal-2588586139-line-12)">
-</text><text class="terminal-2588586139-r1" x="1378.6" y="337.2" textLength="12.2" clip-path="url(#terminal-2588586139-line-13)">
-</text><text class="terminal-2588586139-r1" x="1378.6" y="361.6" textLength="12.2" clip-path="url(#terminal-2588586139-line-14)">
-</text><text class="terminal-2588586139-r1" x="1378.6" y="386" textLength="12.2" clip-path="url(#terminal-2588586139-line-15)">
-</text><text class="terminal-2588586139-r1" x="1378.6" y="410.4" textLength="12.2" clip-path="url(#terminal-2588586139-line-16)">
-</text><text class="terminal-2588586139-r1" x="1378.6" y="434.8" textLength="12.2" clip-path="url(#terminal-2588586139-line-17)">
-</text><text class="terminal-2588586139-r1" x="1378.6" y="459.2" textLength="12.2" clip-path="url(#terminal-2588586139-line-18)">
-</text><text class="terminal-2588586139-r1" x="1378.6" y="483.6" textLength="12.2" clip-path="url(#terminal-2588586139-line-19)">
-</text><text class="terminal-2588586139-r1" x="1378.6" y="508" textLength="12.2" clip-path="url(#terminal-2588586139-line-20)">
-</text><text class="terminal-2588586139-r1" x="1378.6" y="532.4" textLength="12.2" clip-path="url(#terminal-2588586139-line-21)">
-</text><text class="terminal-2588586139-r1" x="1378.6" y="556.8" textLength="12.2" clip-path="url(#terminal-2588586139-line-22)">
-</text><text class="terminal-2588586139-r1" x="1378.6" y="581.2" textLength="12.2" clip-path="url(#terminal-2588586139-line-23)">
-</text><text class="terminal-2588586139-r1" x="1378.6" y="605.6" textLength="12.2" clip-path="url(#terminal-2588586139-line-24)">
-</text><text class="terminal-2588586139-r1" x="1378.6" y="630" textLength="12.2" clip-path="url(#terminal-2588586139-line-25)">
-</text><text class="terminal-2588586139-r1" x="1378.6" y="654.4" textLength="12.2" clip-path="url(#terminal-2588586139-line-26)">
-</text><text class="terminal-2588586139-r1" x="1378.6" y="678.8" textLength="12.2" clip-path="url(#terminal-2588586139-line-27)">
-</text><text class="terminal-2588586139-r1" x="1378.6" y="703.2" textLength="12.2" clip-path="url(#terminal-2588586139-line-28)">
-</text><text class="terminal-2588586139-r1" x="1378.6" y="727.6" textLength="12.2" clip-path="url(#terminal-2588586139-line-29)">
-</text><text class="terminal-2588586139-r1" x="1378.6" y="752" textLength="12.2" clip-path="url(#terminal-2588586139-line-30)">
-</text><text class="terminal-2588586139-r1" x="1378.6" y="776.4" textLength="12.2" clip-path="url(#terminal-2588586139-line-31)">
-</text><text class="terminal-2588586139-r1" x="1378.6" y="800.8" textLength="12.2" clip-path="url(#terminal-2588586139-line-32)">
-</text><text class="terminal-2588586139-r5" x="0" y="825.2" textLength="36.6" clip-path="url(#terminal-2588586139-line-33)">&#160;1&#160;</text><text class="terminal-2588586139-r2" x="36.6" y="825.2" textLength="134.2" clip-path="url(#terminal-2588586139-line-33)">Properties&#160;</text><text class="terminal-2588586139-r5" x="170.8" y="825.2" textLength="36.6" clip-path="url(#terminal-2588586139-line-33)">&#160;2&#160;</text><text class="terminal-2588586139-r2" x="207.4" y="825.2" textLength="231.8" clip-path="url(#terminal-2588586139-line-33)">Inverse&#160;Properties&#160;</text><text class="terminal-2588586139-r5" x="439.2" y="825.2" textLength="48.8" clip-path="url(#terminal-2588586139-line-33)">&#160;f5&#160;</text><text class="terminal-2588586139-r2" x="488" y="825.2" textLength="109.8" clip-path="url(#terminal-2588586139-line-33)">🔄&#160;Reload&#160;</text><text class="terminal-2588586139-r5" x="610" y="825.2" textLength="61" clip-path="url(#terminal-2588586139-line-33)">&#160;f12&#160;</text><text class="terminal-2588586139-r2" x="671" y="825.2" textLength="97.6" clip-path="url(#terminal-2588586139-line-33)">Console&#160;</text><text class="terminal-2588586139-r5" x="768.6" y="825.2" textLength="36.6" clip-path="url(#terminal-2588586139-line-33)">&#160;t&#160;</text><text class="terminal-2588586139-r2" x="805.2" y="825.2" textLength="207.4" clip-path="url(#terminal-2588586139-line-33)">Toggle&#160;Dark&#160;Mode&#160;</text><text class="terminal-2588586139-r5" x="1012.6" y="825.2" textLength="36.6" clip-path="url(#terminal-2588586139-line-33)">&#160;q&#160;</text><text class="terminal-2588586139-r2" x="1049.2" y="825.2" textLength="61" clip-path="url(#terminal-2588586139-line-33)">Quit&#160;</text><text class="terminal-2588586139-r6" x="1232.2" y="825.2" textLength="12.2" clip-path="url(#terminal-2588586139-line-33)">▏</text><text class="terminal-2588586139-r5" x="1244.4" y="825.2" textLength="24.4" clip-path="url(#terminal-2588586139-line-33)">^p</text><text class="terminal-2588586139-r2" x="1268.8" y="825.2" textLength="97.6" clip-path="url(#terminal-2588586139-line-33)">&#160;palette</text>
+    <g transform="translate(9, 41)" clip-path="url(#terminal-2068471928-clip-terminal)">
+    <rect fill="#2d2d2d" x="0" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="12.2" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="24.4" y="1.5" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="85.4" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="97.6" y="1.5" width="256.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="353.8" y="1.5" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="475.8" y="1.5" width="512.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="988.2" y="1.5" width="268.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1256.6" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1268.8" y="1.5" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1268.8" y="1.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1366.4" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#454545" x="0" y="25.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#454545" x="0" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#454545" x="12.2" y="50.3" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#454545" x="146.4" y="50.3" width="1220" height="24.65" shape-rendering="crispEdges"/><rect fill="#454545" x="1366.4" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#454545" x="0" y="74.7" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="99.1" width="427" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="427" y="99.1" width="951.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="123.5" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="48.8" y="123.5" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="195.2" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="207.4" y="123.5" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="353.8" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="366" y="123.5" width="427" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="793" y="123.5" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="854" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="866.2" y="123.5" width="512.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="147.9" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="207.4" y="147.9" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="366" y="147.9" width="427" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="793" y="147.9" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="866.2" y="147.9" width="512.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="172.3" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="134.2" y="172.3" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="195.2" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="207.4" y="172.3" width="378.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="585.6" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="597.8" y="172.3" width="780.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="196.7" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="207.4" y="196.7" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="597.8" y="196.7" width="780.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="221.1" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="122" y="221.1" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="195.2" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="207.4" y="221.1" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="268.4" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="280.6" y="221.1" width="1098" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="245.5" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="207.4" y="245.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="280.6" y="245.5" width="1098" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="269.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="294.3" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="318.7" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="343.1" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="367.5" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="391.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="416.3" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="440.7" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="465.1" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="489.5" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="513.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="538.3" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="562.7" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="587.1" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="611.5" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="635.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="660.3" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="684.7" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="709.1" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="733.5" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="757.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="782.3" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="0" y="806.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="36.6" y="806.7" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="158.6" y="806.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="195.2" y="806.7" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="427" y="806.7" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="475.8" y="806.7" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="597.8" y="806.7" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="658.8" y="806.7" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="756.4" y="806.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="793" y="806.7" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1000.4" y="806.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1037" y="806.7" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1098" y="806.7" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1232.2" y="806.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1244.4" y="806.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1268.8" y="806.7" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1366.4" y="806.7" width="12.2" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-2068471928-matrix">
+    <text class="terminal-2068471928-r2" x="12.2" y="20" textLength="24.4" clip-path="url(#terminal-2068471928-line-0)">👁️</text><text class="terminal-2068471928-r2" x="353.8" y="20" textLength="122" clip-path="url(#terminal-2068471928-line-0)">Iolanta&#160;—&#160;</text><text class="terminal-2068471928-r3" x="475.8" y="20" textLength="512.4" clip-path="url(#terminal-2068471928-line-0)">https://www.w3.org/2002/07/owl#Restriction</text><text class="terminal-2068471928-r1" x="1378.6" y="20" textLength="12.2" clip-path="url(#terminal-2068471928-line-0)">
+</text><text class="terminal-2068471928-r1" x="1378.6" y="44.4" textLength="12.2" clip-path="url(#terminal-2068471928-line-1)">
+</text><text class="terminal-2068471928-r4" x="12.2" y="68.8" textLength="134.2" clip-path="url(#terminal-2068471928-line-2)">Restriction</text><text class="terminal-2068471928-r1" x="1378.6" y="68.8" textLength="12.2" clip-path="url(#terminal-2068471928-line-2)">
+</text><text class="terminal-2068471928-r1" x="1378.6" y="93.2" textLength="12.2" clip-path="url(#terminal-2068471928-line-3)">
+</text><text class="terminal-2068471928-r2" x="0" y="117.6" textLength="427" clip-path="url(#terminal-2068471928-line-4)">The&#160;class&#160;of&#160;property&#160;restrictions.</text><text class="terminal-2068471928-r1" x="1378.6" y="117.6" textLength="12.2" clip-path="url(#terminal-2068471928-line-4)">
+</text><text class="terminal-2068471928-r2" x="0" y="142" textLength="48.8" clip-path="url(#terminal-2068471928-line-5)">type</text><text class="terminal-2068471928-r2" x="207.4" y="142" textLength="146.4" clip-path="url(#terminal-2068471928-line-5)">Restrictions</text><text class="terminal-2068471928-r2" x="793" y="142" textLength="61" clip-path="url(#terminal-2068471928-line-5)">Class</text><text class="terminal-2068471928-r1" x="1378.6" y="142" textLength="12.2" clip-path="url(#terminal-2068471928-line-5)">
+</text><text class="terminal-2068471928-r1" x="1378.6" y="166.4" textLength="12.2" clip-path="url(#terminal-2068471928-line-6)">
+</text><text class="terminal-2068471928-r2" x="0" y="190.8" textLength="134.2" clip-path="url(#terminal-2068471928-line-7)">isDefinedBy</text><text class="terminal-2068471928-r2" x="207.4" y="190.8" textLength="378.2" clip-path="url(#terminal-2068471928-line-7)">https://www.w3.org/2002/07/owl#</text><text class="terminal-2068471928-r1" x="1378.6" y="190.8" textLength="12.2" clip-path="url(#terminal-2068471928-line-7)">
+</text><text class="terminal-2068471928-r1" x="1378.6" y="215.2" textLength="12.2" clip-path="url(#terminal-2068471928-line-8)">
+</text><text class="terminal-2068471928-r2" x="0" y="239.6" textLength="122" clip-path="url(#terminal-2068471928-line-9)">subClassOf</text><text class="terminal-2068471928-r2" x="207.4" y="239.6" textLength="61" clip-path="url(#terminal-2068471928-line-9)">Class</text><text class="terminal-2068471928-r1" x="1378.6" y="239.6" textLength="12.2" clip-path="url(#terminal-2068471928-line-9)">
+</text><text class="terminal-2068471928-r1" x="1378.6" y="264" textLength="12.2" clip-path="url(#terminal-2068471928-line-10)">
+</text><text class="terminal-2068471928-r1" x="1378.6" y="288.4" textLength="12.2" clip-path="url(#terminal-2068471928-line-11)">
+</text><text class="terminal-2068471928-r1" x="1378.6" y="312.8" textLength="12.2" clip-path="url(#terminal-2068471928-line-12)">
+</text><text class="terminal-2068471928-r1" x="1378.6" y="337.2" textLength="12.2" clip-path="url(#terminal-2068471928-line-13)">
+</text><text class="terminal-2068471928-r1" x="1378.6" y="361.6" textLength="12.2" clip-path="url(#terminal-2068471928-line-14)">
+</text><text class="terminal-2068471928-r1" x="1378.6" y="386" textLength="12.2" clip-path="url(#terminal-2068471928-line-15)">
+</text><text class="terminal-2068471928-r1" x="1378.6" y="410.4" textLength="12.2" clip-path="url(#terminal-2068471928-line-16)">
+</text><text class="terminal-2068471928-r1" x="1378.6" y="434.8" textLength="12.2" clip-path="url(#terminal-2068471928-line-17)">
+</text><text class="terminal-2068471928-r1" x="1378.6" y="459.2" textLength="12.2" clip-path="url(#terminal-2068471928-line-18)">
+</text><text class="terminal-2068471928-r1" x="1378.6" y="483.6" textLength="12.2" clip-path="url(#terminal-2068471928-line-19)">
+</text><text class="terminal-2068471928-r1" x="1378.6" y="508" textLength="12.2" clip-path="url(#terminal-2068471928-line-20)">
+</text><text class="terminal-2068471928-r1" x="1378.6" y="532.4" textLength="12.2" clip-path="url(#terminal-2068471928-line-21)">
+</text><text class="terminal-2068471928-r1" x="1378.6" y="556.8" textLength="12.2" clip-path="url(#terminal-2068471928-line-22)">
+</text><text class="terminal-2068471928-r1" x="1378.6" y="581.2" textLength="12.2" clip-path="url(#terminal-2068471928-line-23)">
+</text><text class="terminal-2068471928-r1" x="1378.6" y="605.6" textLength="12.2" clip-path="url(#terminal-2068471928-line-24)">
+</text><text class="terminal-2068471928-r1" x="1378.6" y="630" textLength="12.2" clip-path="url(#terminal-2068471928-line-25)">
+</text><text class="terminal-2068471928-r1" x="1378.6" y="654.4" textLength="12.2" clip-path="url(#terminal-2068471928-line-26)">
+</text><text class="terminal-2068471928-r1" x="1378.6" y="678.8" textLength="12.2" clip-path="url(#terminal-2068471928-line-27)">
+</text><text class="terminal-2068471928-r1" x="1378.6" y="703.2" textLength="12.2" clip-path="url(#terminal-2068471928-line-28)">
+</text><text class="terminal-2068471928-r1" x="1378.6" y="727.6" textLength="12.2" clip-path="url(#terminal-2068471928-line-29)">
+</text><text class="terminal-2068471928-r1" x="1378.6" y="752" textLength="12.2" clip-path="url(#terminal-2068471928-line-30)">
+</text><text class="terminal-2068471928-r1" x="1378.6" y="776.4" textLength="12.2" clip-path="url(#terminal-2068471928-line-31)">
+</text><text class="terminal-2068471928-r1" x="1378.6" y="800.8" textLength="12.2" clip-path="url(#terminal-2068471928-line-32)">
+</text><text class="terminal-2068471928-r5" x="0" y="825.2" textLength="36.6" clip-path="url(#terminal-2068471928-line-33)">&#160;1&#160;</text><text class="terminal-2068471928-r2" x="36.6" y="825.2" textLength="122" clip-path="url(#terminal-2068471928-line-33)">Instances&#160;</text><text class="terminal-2068471928-r5" x="158.6" y="825.2" textLength="36.6" clip-path="url(#terminal-2068471928-line-33)">&#160;3&#160;</text><text class="terminal-2068471928-r2" x="195.2" y="825.2" textLength="231.8" clip-path="url(#terminal-2068471928-line-33)">Inverse&#160;Properties&#160;</text><text class="terminal-2068471928-r5" x="427" y="825.2" textLength="48.8" clip-path="url(#terminal-2068471928-line-33)">&#160;f5&#160;</text><text class="terminal-2068471928-r2" x="475.8" y="825.2" textLength="109.8" clip-path="url(#terminal-2068471928-line-33)">🔄&#160;Reload&#160;</text><text class="terminal-2068471928-r5" x="597.8" y="825.2" textLength="61" clip-path="url(#terminal-2068471928-line-33)">&#160;f12&#160;</text><text class="terminal-2068471928-r2" x="658.8" y="825.2" textLength="97.6" clip-path="url(#terminal-2068471928-line-33)">Console&#160;</text><text class="terminal-2068471928-r5" x="756.4" y="825.2" textLength="36.6" clip-path="url(#terminal-2068471928-line-33)">&#160;t&#160;</text><text class="terminal-2068471928-r2" x="793" y="825.2" textLength="207.4" clip-path="url(#terminal-2068471928-line-33)">Toggle&#160;Dark&#160;Mode&#160;</text><text class="terminal-2068471928-r5" x="1000.4" y="825.2" textLength="36.6" clip-path="url(#terminal-2068471928-line-33)">&#160;q&#160;</text><text class="terminal-2068471928-r2" x="1037" y="825.2" textLength="61" clip-path="url(#terminal-2068471928-line-33)">Quit&#160;</text><text class="terminal-2068471928-r6" x="1232.2" y="825.2" textLength="12.2" clip-path="url(#terminal-2068471928-line-33)">▏</text><text class="terminal-2068471928-r5" x="1244.4" y="825.2" textLength="24.4" clip-path="url(#terminal-2068471928-line-33)">^p</text><text class="terminal-2068471928-r2" x="1268.8" y="825.2" textLength="97.6" clip-path="url(#terminal-2068471928-line-33)">&#160;palette</text>
     </g>
     </g>
 </svg>

--- a/docs/screenshots/www.w3.org.2002.07.owl.restriction.svg
+++ b/docs/screenshots/www.w3.org.2002.07.owl.restriction.svg
@@ -1,0 +1,194 @@
+<svg class="rich-terminal" viewBox="0 0 1397 879.5999999999999" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-2588586139-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-2588586139-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-2588586139-r1 { fill: #c5c8c6 }
+.terminal-2588586139-r2 { fill: #e0e0e0 }
+.terminal-2588586139-r3 { fill: #989898 }
+.terminal-2588586139-r4 { fill: #ffffff;font-weight: bold }
+.terminal-2588586139-r5 { fill: #b0b0b0;font-weight: bold }
+.terminal-2588586139-r6 { fill: #515151 }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-2588586139-clip-terminal">
+      <rect x="0" y="0" width="1377.6" height="828.5999999999999" />
+    </clipPath>
+    <clipPath id="terminal-2588586139-line-0">
+    <rect x="0" y="1.5" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2588586139-line-1">
+    <rect x="0" y="25.9" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2588586139-line-2">
+    <rect x="0" y="50.3" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2588586139-line-3">
+    <rect x="0" y="74.7" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2588586139-line-4">
+    <rect x="0" y="99.1" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2588586139-line-5">
+    <rect x="0" y="123.5" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2588586139-line-6">
+    <rect x="0" y="147.9" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2588586139-line-7">
+    <rect x="0" y="172.3" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2588586139-line-8">
+    <rect x="0" y="196.7" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2588586139-line-9">
+    <rect x="0" y="221.1" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2588586139-line-10">
+    <rect x="0" y="245.5" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2588586139-line-11">
+    <rect x="0" y="269.9" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2588586139-line-12">
+    <rect x="0" y="294.3" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2588586139-line-13">
+    <rect x="0" y="318.7" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2588586139-line-14">
+    <rect x="0" y="343.1" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2588586139-line-15">
+    <rect x="0" y="367.5" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2588586139-line-16">
+    <rect x="0" y="391.9" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2588586139-line-17">
+    <rect x="0" y="416.3" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2588586139-line-18">
+    <rect x="0" y="440.7" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2588586139-line-19">
+    <rect x="0" y="465.1" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2588586139-line-20">
+    <rect x="0" y="489.5" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2588586139-line-21">
+    <rect x="0" y="513.9" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2588586139-line-22">
+    <rect x="0" y="538.3" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2588586139-line-23">
+    <rect x="0" y="562.7" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2588586139-line-24">
+    <rect x="0" y="587.1" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2588586139-line-25">
+    <rect x="0" y="611.5" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2588586139-line-26">
+    <rect x="0" y="635.9" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2588586139-line-27">
+    <rect x="0" y="660.3" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2588586139-line-28">
+    <rect x="0" y="684.7" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2588586139-line-29">
+    <rect x="0" y="709.1" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2588586139-line-30">
+    <rect x="0" y="733.5" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2588586139-line-31">
+    <rect x="0" y="757.9" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2588586139-line-32">
+    <rect x="0" y="782.3" width="1378.6" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1395" height="877.6" rx="8"/><text class="terminal-2588586139-title" fill="#c5c8c6" text-anchor="middle" x="697" y="27">Iolanta</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-2588586139-clip-terminal)">
+    <rect fill="#2d2d2d" x="0" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="12.2" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="24.4" y="1.5" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="85.4" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="97.6" y="1.5" width="256.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="353.8" y="1.5" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="475.8" y="1.5" width="512.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="988.2" y="1.5" width="268.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1256.6" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1268.8" y="1.5" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1268.8" y="1.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1366.4" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#454545" x="0" y="25.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#454545" x="0" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#454545" x="12.2" y="50.3" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#454545" x="146.4" y="50.3" width="1220" height="24.65" shape-rendering="crispEdges"/><rect fill="#454545" x="1366.4" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#454545" x="0" y="74.7" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#333333" x="0" y="99.1" width="915" height="24.65" shape-rendering="crispEdges"/><rect fill="#333333" x="915" y="99.1" width="463.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="123.5" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="147.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="172.3" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="196.7" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="221.1" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="245.5" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="269.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="294.3" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="318.7" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="343.1" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="367.5" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="391.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="416.3" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="440.7" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="465.1" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="489.5" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="513.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="538.3" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="562.7" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="587.1" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="611.5" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="635.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="660.3" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="684.7" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="709.1" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="733.5" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="757.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="782.3" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="0" y="806.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="36.6" y="806.7" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="170.8" y="806.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="207.4" y="806.7" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="439.2" y="806.7" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="488" y="806.7" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="610" y="806.7" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="671" y="806.7" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="768.6" y="806.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="805.2" y="806.7" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1012.6" y="806.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1049.2" y="806.7" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1110.2" y="806.7" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1232.2" y="806.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1244.4" y="806.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1268.8" y="806.7" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1366.4" y="806.7" width="12.2" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-2588586139-matrix">
+    <text class="terminal-2588586139-r2" x="12.2" y="20" textLength="24.4" clip-path="url(#terminal-2588586139-line-0)">👁️</text><text class="terminal-2588586139-r2" x="353.8" y="20" textLength="122" clip-path="url(#terminal-2588586139-line-0)">Iolanta&#160;—&#160;</text><text class="terminal-2588586139-r3" x="475.8" y="20" textLength="512.4" clip-path="url(#terminal-2588586139-line-0)">https://www.w3.org/2002/07/owl#Restriction</text><text class="terminal-2588586139-r1" x="1378.6" y="20" textLength="12.2" clip-path="url(#terminal-2588586139-line-0)">
+</text><text class="terminal-2588586139-r1" x="1378.6" y="44.4" textLength="12.2" clip-path="url(#terminal-2588586139-line-1)">
+</text><text class="terminal-2588586139-r4" x="12.2" y="68.8" textLength="134.2" clip-path="url(#terminal-2588586139-line-2)">Restriction</text><text class="terminal-2588586139-r1" x="1378.6" y="68.8" textLength="12.2" clip-path="url(#terminal-2588586139-line-2)">
+</text><text class="terminal-2588586139-r1" x="1378.6" y="93.2" textLength="12.2" clip-path="url(#terminal-2588586139-line-3)">
+</text><text class="terminal-2588586139-r2" x="0" y="117.6" textLength="915" clip-path="url(#terminal-2588586139-line-4)">https://www.w3.org/2009/08/skos-reference/N0856a4a8e1e84fa090f90d2eb2f6df14</text><text class="terminal-2588586139-r1" x="1378.6" y="117.6" textLength="12.2" clip-path="url(#terminal-2588586139-line-4)">
+</text><text class="terminal-2588586139-r1" x="1378.6" y="142" textLength="12.2" clip-path="url(#terminal-2588586139-line-5)">
+</text><text class="terminal-2588586139-r1" x="1378.6" y="166.4" textLength="12.2" clip-path="url(#terminal-2588586139-line-6)">
+</text><text class="terminal-2588586139-r1" x="1378.6" y="190.8" textLength="12.2" clip-path="url(#terminal-2588586139-line-7)">
+</text><text class="terminal-2588586139-r1" x="1378.6" y="215.2" textLength="12.2" clip-path="url(#terminal-2588586139-line-8)">
+</text><text class="terminal-2588586139-r1" x="1378.6" y="239.6" textLength="12.2" clip-path="url(#terminal-2588586139-line-9)">
+</text><text class="terminal-2588586139-r1" x="1378.6" y="264" textLength="12.2" clip-path="url(#terminal-2588586139-line-10)">
+</text><text class="terminal-2588586139-r1" x="1378.6" y="288.4" textLength="12.2" clip-path="url(#terminal-2588586139-line-11)">
+</text><text class="terminal-2588586139-r1" x="1378.6" y="312.8" textLength="12.2" clip-path="url(#terminal-2588586139-line-12)">
+</text><text class="terminal-2588586139-r1" x="1378.6" y="337.2" textLength="12.2" clip-path="url(#terminal-2588586139-line-13)">
+</text><text class="terminal-2588586139-r1" x="1378.6" y="361.6" textLength="12.2" clip-path="url(#terminal-2588586139-line-14)">
+</text><text class="terminal-2588586139-r1" x="1378.6" y="386" textLength="12.2" clip-path="url(#terminal-2588586139-line-15)">
+</text><text class="terminal-2588586139-r1" x="1378.6" y="410.4" textLength="12.2" clip-path="url(#terminal-2588586139-line-16)">
+</text><text class="terminal-2588586139-r1" x="1378.6" y="434.8" textLength="12.2" clip-path="url(#terminal-2588586139-line-17)">
+</text><text class="terminal-2588586139-r1" x="1378.6" y="459.2" textLength="12.2" clip-path="url(#terminal-2588586139-line-18)">
+</text><text class="terminal-2588586139-r1" x="1378.6" y="483.6" textLength="12.2" clip-path="url(#terminal-2588586139-line-19)">
+</text><text class="terminal-2588586139-r1" x="1378.6" y="508" textLength="12.2" clip-path="url(#terminal-2588586139-line-20)">
+</text><text class="terminal-2588586139-r1" x="1378.6" y="532.4" textLength="12.2" clip-path="url(#terminal-2588586139-line-21)">
+</text><text class="terminal-2588586139-r1" x="1378.6" y="556.8" textLength="12.2" clip-path="url(#terminal-2588586139-line-22)">
+</text><text class="terminal-2588586139-r1" x="1378.6" y="581.2" textLength="12.2" clip-path="url(#terminal-2588586139-line-23)">
+</text><text class="terminal-2588586139-r1" x="1378.6" y="605.6" textLength="12.2" clip-path="url(#terminal-2588586139-line-24)">
+</text><text class="terminal-2588586139-r1" x="1378.6" y="630" textLength="12.2" clip-path="url(#terminal-2588586139-line-25)">
+</text><text class="terminal-2588586139-r1" x="1378.6" y="654.4" textLength="12.2" clip-path="url(#terminal-2588586139-line-26)">
+</text><text class="terminal-2588586139-r1" x="1378.6" y="678.8" textLength="12.2" clip-path="url(#terminal-2588586139-line-27)">
+</text><text class="terminal-2588586139-r1" x="1378.6" y="703.2" textLength="12.2" clip-path="url(#terminal-2588586139-line-28)">
+</text><text class="terminal-2588586139-r1" x="1378.6" y="727.6" textLength="12.2" clip-path="url(#terminal-2588586139-line-29)">
+</text><text class="terminal-2588586139-r1" x="1378.6" y="752" textLength="12.2" clip-path="url(#terminal-2588586139-line-30)">
+</text><text class="terminal-2588586139-r1" x="1378.6" y="776.4" textLength="12.2" clip-path="url(#terminal-2588586139-line-31)">
+</text><text class="terminal-2588586139-r1" x="1378.6" y="800.8" textLength="12.2" clip-path="url(#terminal-2588586139-line-32)">
+</text><text class="terminal-2588586139-r5" x="0" y="825.2" textLength="36.6" clip-path="url(#terminal-2588586139-line-33)">&#160;1&#160;</text><text class="terminal-2588586139-r2" x="36.6" y="825.2" textLength="134.2" clip-path="url(#terminal-2588586139-line-33)">Properties&#160;</text><text class="terminal-2588586139-r5" x="170.8" y="825.2" textLength="36.6" clip-path="url(#terminal-2588586139-line-33)">&#160;2&#160;</text><text class="terminal-2588586139-r2" x="207.4" y="825.2" textLength="231.8" clip-path="url(#terminal-2588586139-line-33)">Inverse&#160;Properties&#160;</text><text class="terminal-2588586139-r5" x="439.2" y="825.2" textLength="48.8" clip-path="url(#terminal-2588586139-line-33)">&#160;f5&#160;</text><text class="terminal-2588586139-r2" x="488" y="825.2" textLength="109.8" clip-path="url(#terminal-2588586139-line-33)">🔄&#160;Reload&#160;</text><text class="terminal-2588586139-r5" x="610" y="825.2" textLength="61" clip-path="url(#terminal-2588586139-line-33)">&#160;f12&#160;</text><text class="terminal-2588586139-r2" x="671" y="825.2" textLength="97.6" clip-path="url(#terminal-2588586139-line-33)">Console&#160;</text><text class="terminal-2588586139-r5" x="768.6" y="825.2" textLength="36.6" clip-path="url(#terminal-2588586139-line-33)">&#160;t&#160;</text><text class="terminal-2588586139-r2" x="805.2" y="825.2" textLength="207.4" clip-path="url(#terminal-2588586139-line-33)">Toggle&#160;Dark&#160;Mode&#160;</text><text class="terminal-2588586139-r5" x="1012.6" y="825.2" textLength="36.6" clip-path="url(#terminal-2588586139-line-33)">&#160;q&#160;</text><text class="terminal-2588586139-r2" x="1049.2" y="825.2" textLength="61" clip-path="url(#terminal-2588586139-line-33)">Quit&#160;</text><text class="terminal-2588586139-r6" x="1232.2" y="825.2" textLength="12.2" clip-path="url(#terminal-2588586139-line-33)">▏</text><text class="terminal-2588586139-r5" x="1244.4" y="825.2" textLength="24.4" clip-path="url(#terminal-2588586139-line-33)">^p</text><text class="terminal-2588586139-r2" x="1268.8" y="825.2" textLength="97.6" clip-path="url(#terminal-2588586139-line-33)">&#160;palette</text>
+    </g>
+    </g>
+</svg>

--- a/docs/screenshots/www.w3.org.2002.07.owl.svg
+++ b/docs/screenshots/www.w3.org.2002.07.owl.svg
@@ -1,0 +1,194 @@
+<svg class="rich-terminal" viewBox="0 0 1397 879.5999999999999" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-939637893-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-939637893-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-939637893-r1 { fill: #c5c8c6 }
+.terminal-939637893-r2 { fill: #e0e0e0 }
+.terminal-939637893-r3 { fill: #989898 }
+.terminal-939637893-r4 { fill: #ffffff;font-weight: bold }
+.terminal-939637893-r5 { fill: #b0b0b0;font-weight: bold }
+.terminal-939637893-r6 { fill: #515151 }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-939637893-clip-terminal">
+      <rect x="0" y="0" width="1377.6" height="828.5999999999999" />
+    </clipPath>
+    <clipPath id="terminal-939637893-line-0">
+    <rect x="0" y="1.5" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-1">
+    <rect x="0" y="25.9" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-2">
+    <rect x="0" y="50.3" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-3">
+    <rect x="0" y="74.7" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-4">
+    <rect x="0" y="99.1" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-5">
+    <rect x="0" y="123.5" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-6">
+    <rect x="0" y="147.9" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-7">
+    <rect x="0" y="172.3" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-8">
+    <rect x="0" y="196.7" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-9">
+    <rect x="0" y="221.1" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-10">
+    <rect x="0" y="245.5" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-11">
+    <rect x="0" y="269.9" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-12">
+    <rect x="0" y="294.3" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-13">
+    <rect x="0" y="318.7" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-14">
+    <rect x="0" y="343.1" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-15">
+    <rect x="0" y="367.5" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-16">
+    <rect x="0" y="391.9" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-17">
+    <rect x="0" y="416.3" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-18">
+    <rect x="0" y="440.7" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-19">
+    <rect x="0" y="465.1" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-20">
+    <rect x="0" y="489.5" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-21">
+    <rect x="0" y="513.9" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-22">
+    <rect x="0" y="538.3" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-23">
+    <rect x="0" y="562.7" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-24">
+    <rect x="0" y="587.1" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-25">
+    <rect x="0" y="611.5" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-26">
+    <rect x="0" y="635.9" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-27">
+    <rect x="0" y="660.3" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-28">
+    <rect x="0" y="684.7" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-29">
+    <rect x="0" y="709.1" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-30">
+    <rect x="0" y="733.5" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-31">
+    <rect x="0" y="757.9" width="1378.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-939637893-line-32">
+    <rect x="0" y="782.3" width="1378.6" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1395" height="877.6" rx="8"/><text class="terminal-939637893-title" fill="#c5c8c6" text-anchor="middle" x="697" y="27">Iolanta</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-939637893-clip-terminal)">
+    <rect fill="#2d2d2d" x="0" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="12.2" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="24.4" y="1.5" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="85.4" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="97.6" y="1.5" width="292.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="390.4" y="1.5" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="512.4" y="1.5" width="439.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="951.6" y="1.5" width="305" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1256.6" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1268.8" y="1.5" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1268.8" y="1.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1366.4" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#454545" x="0" y="25.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#454545" x="0" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#454545" x="12.2" y="50.3" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#454545" x="73.2" y="50.3" width="1293.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#454545" x="1366.4" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#454545" x="0" y="74.7" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="99.1" width="1220" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1220" y="99.1" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="123.5" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="48.8" y="123.5" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="195.2" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="207.4" y="123.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="305" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="317.2" y="123.5" width="1061.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="147.9" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="207.4" y="147.9" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="317.2" y="147.9" width="1061.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="172.3" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="73.2" y="172.3" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="195.2" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="207.4" y="172.3" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="268.4" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="280.6" y="172.3" width="1098" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="196.7" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="207.4" y="196.7" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="280.6" y="196.7" width="1098" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="221.1" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="134.2" y="221.1" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="195.2" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="207.4" y="221.1" width="378.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="585.6" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="597.8" y="221.1" width="780.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="245.5" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="207.4" y="245.5" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="597.8" y="245.5" width="780.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="269.9" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="61" y="269.9" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="195.2" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="207.4" y="269.9" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="256.2" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="268.4" y="269.9" width="1110.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="294.3" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="207.4" y="294.3" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="268.4" y="294.3" width="1110.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="318.7" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="343.1" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="367.5" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="391.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="416.3" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="440.7" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="465.1" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="489.5" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="513.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="538.3" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="562.7" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="587.1" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="611.5" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="635.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="660.3" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="684.7" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="709.1" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="733.5" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="757.9" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="782.3" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="0" y="806.7" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="48.8" y="806.7" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="170.8" y="806.7" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="231.8" y="806.7" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="329.4" y="806.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="366" y="806.7" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="573.4" y="806.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="610" y="806.7" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="671" y="806.7" width="561.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1232.2" y="806.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1244.4" y="806.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1268.8" y="806.7" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d2d2d" x="1366.4" y="806.7" width="12.2" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-939637893-matrix">
+    <text class="terminal-939637893-r2" x="12.2" y="20" textLength="24.4" clip-path="url(#terminal-939637893-line-0)">👁️</text><text class="terminal-939637893-r2" x="390.4" y="20" textLength="122" clip-path="url(#terminal-939637893-line-0)">Iolanta&#160;—&#160;</text><text class="terminal-939637893-r3" x="512.4" y="20" textLength="439.2" clip-path="url(#terminal-939637893-line-0)">https://www.w3.org/2002/07/owl#oneOf</text><text class="terminal-939637893-r1" x="1378.6" y="20" textLength="12.2" clip-path="url(#terminal-939637893-line-0)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="44.4" textLength="12.2" clip-path="url(#terminal-939637893-line-1)">
+</text><text class="terminal-939637893-r4" x="12.2" y="68.8" textLength="61" clip-path="url(#terminal-939637893-line-2)">oneOf</text><text class="terminal-939637893-r1" x="1378.6" y="68.8" textLength="12.2" clip-path="url(#terminal-939637893-line-2)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="93.2" textLength="12.2" clip-path="url(#terminal-939637893-line-3)">
+</text><text class="terminal-939637893-r2" x="0" y="117.6" textLength="1220" clip-path="url(#terminal-939637893-line-4)">The&#160;property&#160;that&#160;determines&#160;the&#160;collection&#160;of&#160;individuals&#160;or&#160;data&#160;values&#160;that&#160;build&#160;an&#160;enumeration.</text><text class="terminal-939637893-r1" x="1378.6" y="117.6" textLength="12.2" clip-path="url(#terminal-939637893-line-4)">
+</text><text class="terminal-939637893-r2" x="0" y="142" textLength="48.8" clip-path="url(#terminal-939637893-line-5)">type</text><text class="terminal-939637893-r2" x="207.4" y="142" textLength="97.6" clip-path="url(#terminal-939637893-line-5)">Property</text><text class="terminal-939637893-r1" x="1378.6" y="142" textLength="12.2" clip-path="url(#terminal-939637893-line-5)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="166.4" textLength="12.2" clip-path="url(#terminal-939637893-line-6)">
+</text><text class="terminal-939637893-r2" x="0" y="190.8" textLength="73.2" clip-path="url(#terminal-939637893-line-7)">domain</text><text class="terminal-939637893-r2" x="207.4" y="190.8" textLength="61" clip-path="url(#terminal-939637893-line-7)">Class</text><text class="terminal-939637893-r1" x="1378.6" y="190.8" textLength="12.2" clip-path="url(#terminal-939637893-line-7)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="215.2" textLength="12.2" clip-path="url(#terminal-939637893-line-8)">
+</text><text class="terminal-939637893-r2" x="0" y="239.6" textLength="134.2" clip-path="url(#terminal-939637893-line-9)">isDefinedBy</text><text class="terminal-939637893-r2" x="207.4" y="239.6" textLength="378.2" clip-path="url(#terminal-939637893-line-9)">https://www.w3.org/2002/07/owl#</text><text class="terminal-939637893-r1" x="1378.6" y="239.6" textLength="12.2" clip-path="url(#terminal-939637893-line-9)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="264" textLength="12.2" clip-path="url(#terminal-939637893-line-10)">
+</text><text class="terminal-939637893-r2" x="0" y="288.4" textLength="61" clip-path="url(#terminal-939637893-line-11)">range</text><text class="terminal-939637893-r2" x="207.4" y="288.4" textLength="48.8" clip-path="url(#terminal-939637893-line-11)">List</text><text class="terminal-939637893-r1" x="1378.6" y="288.4" textLength="12.2" clip-path="url(#terminal-939637893-line-11)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="312.8" textLength="12.2" clip-path="url(#terminal-939637893-line-12)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="337.2" textLength="12.2" clip-path="url(#terminal-939637893-line-13)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="361.6" textLength="12.2" clip-path="url(#terminal-939637893-line-14)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="386" textLength="12.2" clip-path="url(#terminal-939637893-line-15)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="410.4" textLength="12.2" clip-path="url(#terminal-939637893-line-16)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="434.8" textLength="12.2" clip-path="url(#terminal-939637893-line-17)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="459.2" textLength="12.2" clip-path="url(#terminal-939637893-line-18)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="483.6" textLength="12.2" clip-path="url(#terminal-939637893-line-19)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="508" textLength="12.2" clip-path="url(#terminal-939637893-line-20)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="532.4" textLength="12.2" clip-path="url(#terminal-939637893-line-21)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="556.8" textLength="12.2" clip-path="url(#terminal-939637893-line-22)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="581.2" textLength="12.2" clip-path="url(#terminal-939637893-line-23)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="605.6" textLength="12.2" clip-path="url(#terminal-939637893-line-24)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="630" textLength="12.2" clip-path="url(#terminal-939637893-line-25)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="654.4" textLength="12.2" clip-path="url(#terminal-939637893-line-26)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="678.8" textLength="12.2" clip-path="url(#terminal-939637893-line-27)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="703.2" textLength="12.2" clip-path="url(#terminal-939637893-line-28)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="727.6" textLength="12.2" clip-path="url(#terminal-939637893-line-29)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="752" textLength="12.2" clip-path="url(#terminal-939637893-line-30)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="776.4" textLength="12.2" clip-path="url(#terminal-939637893-line-31)">
+</text><text class="terminal-939637893-r1" x="1378.6" y="800.8" textLength="12.2" clip-path="url(#terminal-939637893-line-32)">
+</text><text class="terminal-939637893-r5" x="0" y="825.2" textLength="48.8" clip-path="url(#terminal-939637893-line-33)">&#160;f5&#160;</text><text class="terminal-939637893-r2" x="48.8" y="825.2" textLength="109.8" clip-path="url(#terminal-939637893-line-33)">🔄&#160;Reload&#160;</text><text class="terminal-939637893-r5" x="170.8" y="825.2" textLength="61" clip-path="url(#terminal-939637893-line-33)">&#160;f12&#160;</text><text class="terminal-939637893-r2" x="231.8" y="825.2" textLength="97.6" clip-path="url(#terminal-939637893-line-33)">Console&#160;</text><text class="terminal-939637893-r5" x="329.4" y="825.2" textLength="36.6" clip-path="url(#terminal-939637893-line-33)">&#160;t&#160;</text><text class="terminal-939637893-r2" x="366" y="825.2" textLength="207.4" clip-path="url(#terminal-939637893-line-33)">Toggle&#160;Dark&#160;Mode&#160;</text><text class="terminal-939637893-r5" x="573.4" y="825.2" textLength="36.6" clip-path="url(#terminal-939637893-line-33)">&#160;q&#160;</text><text class="terminal-939637893-r2" x="610" y="825.2" textLength="61" clip-path="url(#terminal-939637893-line-33)">Quit&#160;</text><text class="terminal-939637893-r6" x="1232.2" y="825.2" textLength="12.2" clip-path="url(#terminal-939637893-line-33)">▏</text><text class="terminal-939637893-r5" x="1244.4" y="825.2" textLength="24.4" clip-path="url(#terminal-939637893-line-33)">^p</text><text class="terminal-939637893-r2" x="1268.8" y="825.2" textLength="97.6" clip-path="url(#terminal-939637893-line-33)">&#160;palette</text>
+    </g>
+    </g>
+</svg>


### PR DESCRIPTION
- **Disable highlighting and markup in dev console**
- **Change unknown SPARQL expression log level from error to info**
- **Register textual-graphs facet plugin**
- **Add integration tests for RDFG Graph and meta graph**
- **Add MC-2 knowledge graph assignment blog post**
- **Add textual-graphs facet for visualizing named graphs**
- **Add screenshots for RDFG Graph and meta graph tests**
- **Bump version to 2.1.6**
- **Update Screenshots**
- **Add rdfg and xsd namespace prefixes to context**
- **Document iolanta:last-loaded-time property and add OWL visualization examples**
- **Update _meta screenshot with refreshed timestamps**
- **Update OWL Restriction screenshot with improved rendering**
- **Add tests for OWL properties and improve screenshot generation with fragment support**
- **Add iolanta:last-loaded-time property definition**
- **Add screenshot for OWL oneOf property visualization**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds docs and ontology for `iolanta:last-loaded-time`, OWL visualization examples, improved screenshot generation, expanded integration tests, and updated context/screenshots.
> 
> - **Docs (MC-2)**:
>   - Document and demo `iolanta:last-loaded-time` with example YAML-LD and CLI render; add OWL `oneOf` and `Restriction` visualization examples.
> - **Ontology/Data**:
>   - Add `docs/blog/knowledge-graph-assignment/mc2/last-updated-time.yamlld` defining `iolanta:last-loaded-time` (`owl:DatatypeProperty`, domain `rdfg:Graph`, range `xsd:dateTime`, subPropertyOf `schema:dateModified`).
>   - Extend context with `rdfg` and `xsd` prefixes.
> - **Testing/Tooling**:
>   - Enhance screenshot generator: support URL fragment-based filenames; force color; fixed terminal size.
>   - Add integration tests for OWL `oneOf`, `Restriction`, and `iolanta:last-loaded-time`; add YAML-LD spec namespace-prefixes test.
> - **Assets**:
>   - Update `_meta` screenshot (refreshed timestamps) and add new screenshots for `last-updated-time.yamlld`, OWL `oneOf`, and `Restriction`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ba27c32af0dc55efac9be405d7794d51ab158bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->