### PR TITLE
214 iolanta foaf crashes

### DIFF
--- a/docs/decisions/download-data-while-executing-sparql/state-of-the-art.yaml
+++ b/docs/decisions/download-data-while-executing-sparql/state-of-the-art.yaml
@@ -1,7 +1,7 @@
 "@context":
   "@import": https://json-ld.org/contexts/dollar-convenience.jsonld
-  vann: https://purl.org/vocab/vann/
-  foaf: https://xmlns.com/foaf/0.1/
+  vann: http://purl.org/vocab/vann/
+  foaf: http://xmlns.com/foaf/0.1/
   owl: https://www.w3.org/2002/07/owl#
   iolanta: https://iolanta.tech/
   rdfs: "http://www.w3.org/2000/01/rdf-schema#"

--- a/docs/visualizations/dcterms.yaml
+++ b/docs/visualizations/dcterms.yaml
@@ -1,13 +1,13 @@
 "@context":
   "@import": https://json-ld.org/contexts/dollar-convenience.jsonld
-  vann: https://purl.org/vocab/vann/
-  foaf: https://xmlns.com/foaf/0.1/
-  owl: https://www.w3.org/2002/07/owl#
+  vann: http://purl.org/vocab/vann/
+  foaf: http://xmlns.com/foaf/0.1/
+  owl: http://www.w3.org/2002/07/owl#
   iolanta: https://iolanta.tech/
   rdfs: "http://www.w3.org/2000/01/rdf-schema#"
   rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
-  dcterms: https://purl.org/dc/terms/
-  dcam: https://purl.org/dc/dcam/
+  dcterms: http://purl.org/dc/terms/
+  dcam: http://purl.org/dc/dcam/
 
 $id: "dcterms:"
 $type: owl:Ontology

--- a/docs/visualizations/foaf.yaml
+++ b/docs/visualizations/foaf.yaml
@@ -1,8 +1,8 @@
 "@context":
   "@import": https://json-ld.org/contexts/dollar-convenience.jsonld
-  vann: https://purl.org/vocab/vann/
-  foaf: https://xmlns.com/foaf/0.1/
-  owl: https://www.w3.org/2002/07/owl#
+  vann: http://purl.org/vocab/vann/
+  foaf: http://xmlns.com/foaf/0.1/
+  owl: http://www.w3.org/2002/07/owl#
   iolanta: https://iolanta.tech/
   rdfs: "http://www.w3.org/2000/01/rdf-schema#"
   rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#

--- a/docs/visualizations/owl.yaml
+++ b/docs/visualizations/owl.yaml
@@ -1,13 +1,13 @@
 "@context":
   "@import": https://json-ld.org/contexts/dollar-convenience.jsonld
-  vann: https://purl.org/vocab/vann/
-  foaf: https://xmlns.com/foaf/0.1/
-  owl: https://www.w3.org/2002/07/owl#
+  vann: http://purl.org/vocab/vann/
+  foaf: http://xmlns.com/foaf/0.1/
+  owl: http://www.w3.org/2002/07/owl#
   iolanta: https://iolanta.tech/
   rdfs: "http://www.w3.org/2000/01/rdf-schema#"
   rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
-  dcterms: https://purl.org/dc/terms/
-  dcam: https://purl.org/dc/dcam/
+  dcterms: http://purl.org/dc/terms/
+  dcam: http://purl.org/dc/dcam/
 
 $id: "owl:"
 $type: owl:Ontology

--- a/docs/visualizations/rdf.yaml
+++ b/docs/visualizations/rdf.yaml
@@ -1,8 +1,8 @@
 "@context":
   "@import": https://json-ld.org/contexts/dollar-convenience.jsonld
-  vann: https://purl.org/vocab/vann/
-  foaf: https://xmlns.com/foaf/0.1/
-  owl: https://www.w3.org/2002/07/owl#
+  vann: http://purl.org/vocab/vann/
+  foaf: http://xmlns.com/foaf/0.1/
+  owl: http://www.w3.org/2002/07/owl#
   iolanta: https://iolanta.tech/
   rdfs: "http://www.w3.org/2000/01/rdf-schema#"
   rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#

--- a/docs/visualizations/rdfs.yaml
+++ b/docs/visualizations/rdfs.yaml
@@ -1,8 +1,8 @@
 "@context":
   "@import": https://json-ld.org/contexts/dollar-convenience.jsonld
-  vann: https://purl.org/vocab/vann/
-  foaf: https://xmlns.com/foaf/0.1/
-  owl: https://www.w3.org/2002/07/owl#
+  vann: http://purl.org/vocab/vann/
+  foaf: http://xmlns.com/foaf/0.1/
+  owl: http://www.w3.org/2002/07/owl#
   iolanta: https://iolanta.tech/
   rdfs: "http://www.w3.org/2000/01/rdf-schema#"
   rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#

--- a/iolanta/data/iolanta.yaml
+++ b/iolanta/data/iolanta.yaml
@@ -1,8 +1,8 @@
 "@context":
   "@import": https://json-ld.org/contexts/dollar-convenience.jsonld
-  vann: https://purl.org/vocab/vann/
-  foaf: https://xmlns.com/foaf/0.1/
-  owl: https://www.w3.org/2002/07/owl#
+  vann: http://purl.org/vocab/vann/
+  foaf: http://xmlns.com/foaf/0.1/
+  owl: http://www.w3.org/2002/07/owl#
   iolanta: https://iolanta.tech/
   rdfs: "http://www.w3.org/2000/01/rdf-schema#"
   rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#

--- a/iolanta/namespaces.py
+++ b/iolanta/namespaces.py
@@ -32,11 +32,11 @@ class DCTERMS(rdflib.DCTERMS):
 
 
 class VANN(rdflib.VANN):
-    _NS = rdflib.Namespace('https://purl.org/vocab/vann/')
+    ...
 
 
 class FOAF(rdflib.FOAF):
-    _NS = rdflib.Namespace('https://xmlns.com/foaf/0.1/')
+    ...
 
 
 class XSD(rdflib.XSD):

--- a/iolanta/sparqlspace/processor.py
+++ b/iolanta/sparqlspace/processor.py
@@ -58,7 +58,7 @@ REDIRECTS = MappingProxyType({
     # FIXME This is presently hardcoded; we need to
     #   - either find a way to resolve these URLs automatically,
     #   - or create a repository of those redirects online.
-    'https://purl.org/vocab/vann/': URIRef(
+    'http://purl.org/vocab/vann/': URIRef(
         'https://vocab.org/vann/vann-vocab-20100607.rdf',
     ),
     URIRef(DC): URIRef(DCTERMS),
@@ -66,8 +66,10 @@ REDIRECTS = MappingProxyType({
     URIRef(RDFS): URIRef(RDFS),
     URIRef(OWL): URIRef(OWL),
 
-    # This one does not answer via HTTPS :(
-    URIRef('https://xmlns.com/foaf/0.1/'): URIRef('http://xmlns.com/foaf/0.1/'),
+    # Redirect FOAF namespace to GitHub mirror
+    URIRef('https?://xmlns.com/foaf/0.1/.+'): URIRef(
+        'https://raw.githubusercontent.com/foaf/foaf/refs/heads/master/xmlns.com/htdocs/foaf/0.1/index.rdf',
+    ),
     URIRef('https://www.nanopub.org/nschema'): URIRef(
         'https://www.nanopub.net/nschema#',
     ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iolanta"
-version = "2.1.8"
+version = "2.1.9"
 description = "Semantic Web browser"
 authors = ["Anatoly Scherbakov <altaisoft@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
- **#214 Redirect FOAF namespace URLs to GitHub mirror via regex pattern**
- **#214 Use default namespace URLs for `VANN` & `FOAF`**
- **#214 Standardize namespace URLs `https://` → `http://`**
- **#214 Bump version 2.1.8 → 2.1.9**
- **#214 Standardize namespace URLs `https://` → `http://`**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes ontology namespace URLs to http and adds a regex redirect to a GitHub mirror for FOAF; bumps version to 2.1.9.
> 
> - **SPARQL loading/redirects**:
>   - Update `REDIRECTS` to use `http://purl.org/vocab/vann/` and add regex-based FOAF redirect to GitHub mirror in `iolanta/sparqlspace/processor.py`.
> - **Namespaces**:
>   - Stop hardcoding `_NS` for `VANN` and `FOAF` in `iolanta/namespaces.py` (use rdflib defaults).
> - **Docs / JSON-LD contexts**:
>   - Standardize `@context` namespace URIs to `http://` for `vann`, `foaf`, `owl`, `dcterms`, `dcam` across:
>     - `docs/decisions/.../state-of-the-art.yaml`
>     - `docs/visualizations/{dcterms,foaf,owl,rdf,rdfs}.yaml`
>     - `iolanta/data/iolanta.yaml`
> - **Version**:
>   - Bump `pyproject.toml` version `2.1.8` → `2.1.9`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89db7660168cf3856767f9da498df0be264b6449. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->