### PR TITLE
339 facet should have ⩾ 1 data types it outputs

### DIFF
--- a/iolanta/data/iolanta.yaml
+++ b/iolanta/data/iolanta.yaml
@@ -7,9 +7,17 @@
   rdfs: "http://www.w3.org/2000/01/rdf-schema#"
   rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
 
+  owl:onProperty:
+    "@type": "@id"
+
 $included:
   - $id: iolanta:Facet
-    $type: rdfs:Class
+    $type: owl:Class
+    rdfs:subClassOf:
+      $type: owl:Restriction
+      owl:onProperty: iolanta:outputs
+      owl:minCardinality: 1
+
     label: Application capable to represent certain nodes of a semantic graph in a form suitable for certain user to interact with.
 
   - $id: iolanta:OutputDatatype

--- a/iolanta/data/textual-browser.yaml
+++ b/iolanta/data/textual-browser.yaml
@@ -70,15 +70,6 @@
         FILTER (?graph != <iolanta://_meta>)
       }
 
-  - $id: pkg:pypi/iolanta#textual-inverse-properties
-    $: Inverse Properties
-    →: https://iolanta.tech/cli/textual
-    ↦: |
-      ASK WHERE {
-        GRAPH ?graph { ?something ?property $this }
-        FILTER (?graph != <iolanta://_meta>)
-      }
-
   - $id: "urn:"
     iolanta:hasFacetByPrefix:
       $id: pkg:pypi/iolanta#textual-provenance

--- a/iolanta/facets/textual_browser/page_switcher.py
+++ b/iolanta/facets/textual_browser/page_switcher.py
@@ -274,12 +274,17 @@ class PageSwitcher(IolantaWidgetMixin, ContentSwitcher):  # noqa: WPS214
         facet_iri: str | None = None,
     ):
         """Go to an IRI."""
-        # Convert string to URIRef if needed.
+        # Convert string to Node if needed.
         # This happens when called via Textual action strings (from keyboard bindings
-        # in page.py line 24), which serialize URIRefs to strings in f-strings.
-        # Direct calls (like line 77) pass URIRef objects directly.
+        # in page.py line 24), which serialize nodes to strings in f-strings.
+        # Direct calls (like line 77) pass Node objects directly.
         if isinstance(this, str):
-            this = URIRef(this)
+            # Check if string represents a blank node (starts with "_:")
+            if this.startswith('_:'):
+                # Create a BNode with the full string (including the "_:")
+                this = BNode(this)
+            else:
+                this = URIRef(this)
         
         self.run_worker(
             functools.partial(

--- a/iolanta/facets/textual_default/facets.py
+++ b/iolanta/facets/textual_default/facets.py
@@ -1,4 +1,5 @@
 import functools
+from pathlib import Path
 from xml.dom import minidom  # noqa: S408
 
 import funcy
@@ -177,6 +178,7 @@ class PageFooter(PageTitle):
 class InverseProperties(TextualDefaultFacet):
     """Inverse properties view."""
 
+    META = Path(__file__).parent / 'textual-inverse-properties.yamlld'
     query_file_name = 'inverse-properties.sparql'
     properties_on_the_right = True
 

--- a/iolanta/facets/textual_default/textual-inverse-properties.yamlld
+++ b/iolanta/facets/textual_default/textual-inverse-properties.yamlld
@@ -1,0 +1,25 @@
+"@context":
+  "@import": https://json-ld.org/contexts/dollar-convenience.jsonld
+  iolanta: https://iolanta.tech/
+  rdfs: "http://www.w3.org/2000/01/rdf-schema#"
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
+
+  $: rdfs:label
+  →:
+    "@type": "@id"
+    "@id": iolanta:outputs
+  ⪯:
+    "@type": "@id"
+    "@id": iolanta:is-preferred-over
+  ↦: iolanta:matches
+
+$id: pkg:pypi/iolanta#textual-inverse-properties
+
+$: Inverse Properties
+→: https://iolanta.tech/cli/textual
+
+↦: |
+  ASK WHERE {
+    GRAPH ?graph { ?something ?property $this }
+    FILTER (?graph != <iolanta://_meta>)
+  }

--- a/iolanta/facets/title/facets.py
+++ b/iolanta/facets/title/facets.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import funcy
 from rdflib import URIRef
 
@@ -16,6 +18,8 @@ PRIORITIES = [   # noqa: WPS407
 
 class TitleFacet(Facet[str]):
     """Title of an object."""
+
+    META = Path(__file__).parent / 'title.yamlld'
 
     def show(self) -> str:
         """Render title of a thing."""

--- a/iolanta/facets/title/title.yamlld
+++ b/iolanta/facets/title/title.yamlld
@@ -1,0 +1,33 @@
+"@context":
+  "@import": https://json-ld.org/contexts/dollar-convenience.jsonld
+  iolanta: https://iolanta.tech/
+  rdfs: "http://www.w3.org/2000/01/rdf-schema#"
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
+  xsd: http://www.w3.org/2001/XMLSchema#
+
+  $: rdfs:label
+  →:
+    "@type": "@id"
+    "@id": iolanta:outputs
+  ⪯:
+    "@type": "@id"
+    "@id": iolanta:is-preferred-over
+  ⊆:
+    "@type": "@id"
+    "@id": rdfs:subClassOf
+  iolanta:hasDefaultFacet:
+    "@type": "@id"
+
+$id: pkg:pypi/iolanta#title
+
+$: Title
+→: https://iolanta.tech/datatypes/title
+
+"@included":
+  - $id: https://iolanta.tech/datatypes/title
+    $type: iolanta:OutputDatatype
+    $: Title
+    rdfs:comment: >
+      A short string naming something. Used in links, lists, page titles, property tables, and many other cases.
+    ⊆: xsd:string
+    iolanta:hasDefaultFacet: pkg:pypi/iolanta#title

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iolanta"
-version = "2.1.9"
+version = "2.1.10"
 description = "Semantic Web browser"
 authors = ["Anatoly Scherbakov <altaisoft@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
- **#339 Fix blank node handling in `action_goto` to preserve `_:` prefix**
- **#339 Add blank node detection in `load()` & filter BNodes from SPARQL extraction**
- **#339 ➕ `META` attribute to `TitleFacet`**
- **#339 ➕ `title.yamlld` metadata file for `TitleFacet`**
- **#339 ➕ `META` attribute to `InverseProperties`**
- **#339 ➕ `textual-inverse-properties.yamlld` metadata file**
- **#339 🧹 `textual-inverse-properties` definition from `textual-browser.yaml`**
- **#339 Change `iolanta:Facet` from `rdfs:Class` → `owl:Class` & ➕ OWL restriction**
- **#339 Bump version 2.1.9 → 2.1.10**
