### PR TITLE
Publish `v0.1.yamlld` context for `roadmap` plugin

### DIFF
--- a/docs/roadmap/contexts/v0.1.yamlld
+++ b/docs/roadmap/contexts/v0.1.yamlld
@@ -1,0 +1,26 @@
+"@context":
+  "@import": https://json-ld.org/contexts/dollar-convenience.jsonld
+  roadmap: https://iolanta.tech/roadmap/
+  rdfs: http://www.w3.org/2000/01/rdf-schema#
+
+  $: rdfs:label
+  
+  →:
+    "@id": roadmap:blocks
+    "@type": "@id"
+  
+  ←:
+    "@id": roadmap:is-blocked-by
+    "@type": "@id"
+  
+  blocks:
+    "@id": roadmap:blocks
+    "@type": "@id"
+  
+  is-blocked-by:
+    "@id": roadmap:is-blocked-by
+    "@type": "@id"
+  
+  tasks:
+    "@id": roadmap:has-task
+    "@type": "@id"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces the initial JSON-LD context for the roadmap plugin.
> 
> - New `docs/roadmap/contexts/v0.1.yamlld` with `@import` of dollar convenience, namespaces for `roadmap` and `rdfs`, and `$` aliasing to `rdfs:label`
> - Declares relations: `→`/`blocks` → `roadmap:blocks`, `←`/`is-blocked-by` → `roadmap:is-blocked-by`, and `tasks` → `roadmap:has-task` (all `@type: @id`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b73f1841696c9c87af26bd2f4f9d5ffc45f060c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->