### PR TITLE
url breaks mermaid

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,3 +3,4 @@ per-file-ignores =
     iolanta/sparqlspace/processor.py:WPS201,WPS202,WPS402
     jeeves/__init__.py:WPS412,WPS400
     tests/test_integration.py:WPS202
+    iolanta/mermaid/models.py:WPS202

--- a/docs/roadmap/iolanta-development-roadmap.yamlld
+++ b/docs/roadmap/iolanta-development-roadmap.yamlld
@@ -95,3 +95,6 @@ tasks:
 
   - $type: Bug
     $: Inference depends on alphabetical order of its CONSTRUCT queries
+
+  - $type: Bug
+    $: <code>mermaid</code> datatype from roadmap plugin does not resolve nor is documented


### PR DESCRIPTION
- **Fix Mermaid syntax: escape quotes in labels & sanitize URL node IDs**
- **Add WPS202 exception for mermaid/models.py**
- **Add bug entry about mermaid datatype resolution**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves Mermaid diagram robustness and rendering.
> 
> - `escape_label` now strips URL prefixes, escapes quotes, and returns labels wrapped in optimal quotes (chooses single vs double)
> - Sanitizes `MermaidURINode.id` with broader charset replacement (`[:\/\.#()?=&+]`)
> - Updates Mermaid templates to use pre-quoted labels: `MermaidBlankNode` `({self.escaped_title})`, `MermaidEdge` `([{self.escaped_title}])`, and `MermaidSubgraph` `[ {self.escaped_title} ]`
> - Adds per-file ignore `WPS202` for `iolanta/mermaid/models.py` in `.flake8`
> - Adds a roadmap bug entry documenting unresolved `mermaid` datatype
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61d2055608ab7252bb5a344eeefecbcfda5070a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->