### PR TITLE
iolanta query

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,14 @@
 
 **F04.** Never catch broad exceptions like `Exception` or `BaseException`. This is an antipattern that hides bugs, masks real problems, makes debugging harder, and violates the principle of catching only what you expect. Always catch specific exception types (e.g., `AttributeError`, `ValueError`, `KeyError`) that you actually expect and know how to handle. If you need to suppress a linting error about exception handling, use `# noqa` rather than changing the exception handling logic.
 
+**F05.** Condense try...except blocks to minimize their size. Extract common error handling logic into helper functions rather than duplicating it across multiple exception handlers. Use tuple exception catching (e.g., `except (Error1, Error2) as error:`) when multiple exceptions are handled identically.
+
+**F06.** Only put code in try blocks that can actually raise exceptions. Move operations that are unlikely or cannot raise exceptions (e.g., simple assignments, property access, object construction that doesn't involve I/O or parsing) outside of try blocks. This makes the code clearer about what can fail and reduces unnecessary exception handling overhead.
+
+**F07.** A branch that should never execute must never exist. Remove defensive `else` branches, `assert False` statements, or similar "this should never happen" code paths. If the type system or logic guarantees a branch is unreachable, trust it and remove the unreachable code. If you're concerned about future changes, use type checking and tests instead of defensive runtime checks.
+
+**F08.** Multiple if...elif branches with `isinstance()` calls must be replaced with `match/case` statements. The `match/case` syntax (Python 3.10+) is more readable, type-safe, and idiomatic for type-based dispatch. Use `match value: case Type():` instead of `if isinstance(value, Type): ... elif isinstance(value, OtherType): ...`.
+
 ## Adding Jeeves Commands
 
 **J00.** Jeeves is a task runner based on Typer. To add a new development command, add a function to `jeeves/__init__.py`. Functions in this module automatically become commands accessible via `j <command-name>`.

--- a/iolanta/facets/query/ask_result_csv.py
+++ b/iolanta/facets/query/ask_result_csv.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from rdflib import Literal
+
+from iolanta.facets.cli.base import Renderable, RichFacet
+from iolanta.facets.errors import NotALiteral
+
+META = Path(__file__).parent / 'data' / 'query_result.yamlld'
+
+
+class AskResultCsvFacet(RichFacet):
+    """Render ASK query results as CSV."""
+
+    META = META
+
+    def show(self) -> Renderable:
+        """Render bool (ASK result) as CSV."""
+        if not isinstance(self.this, Literal):
+            raise NotALiteral(node=self.this)
+
+        query_result = self.this.value
+
+        return "result\n" + str(query_result).lower()

--- a/iolanta/facets/query/ask_result_json.py
+++ b/iolanta/facets/query/ask_result_json.py
@@ -1,0 +1,24 @@
+import json
+from pathlib import Path
+
+from rdflib import Literal
+
+from iolanta.facets.cli.base import Renderable, RichFacet
+from iolanta.facets.errors import NotALiteral
+
+META = Path(__file__).parent / 'data' / 'query_result.yamlld'
+
+
+class AskResultJsonFacet(RichFacet):
+    """Render ASK query results as JSON."""
+
+    META = META
+
+    def show(self) -> Renderable:
+        """Render bool (ASK result) as JSON."""
+        if not isinstance(self.this, Literal):
+            raise NotALiteral(node=self.this)
+
+        query_result = self.this.value
+
+        return json.dumps(query_result)

--- a/iolanta/facets/query/ask_result_table.py
+++ b/iolanta/facets/query/ask_result_table.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from rdflib import Literal
+
+from iolanta.facets.cli.base import Renderable, RichFacet
+from iolanta.facets.errors import NotALiteral
+
+META = Path(__file__).parent / 'data' / 'query_result.yamlld'
+
+
+class AskResultTableFacet(RichFacet):
+    """Render ASK query results as table/text."""
+
+    META = META
+
+    def show(self) -> Renderable:
+        """Render bool (ASK result) as text."""
+        if not isinstance(self.this, Literal):
+            raise NotALiteral(node=self.this)
+
+        query_result = self.this.value
+
+        return "✅ `True`" if query_result else "❌ `False`"

--- a/iolanta/facets/query/construct_result_csv.py
+++ b/iolanta/facets/query/construct_result_csv.py
@@ -1,0 +1,34 @@
+import csv
+import io
+from pathlib import Path
+from typing import cast
+
+from rdflib import Graph, Literal
+
+from iolanta.facets.cli.base import Renderable, RichFacet
+from iolanta.facets.errors import NotALiteral
+
+META = Path(__file__).parent / 'data' / 'query_result.yamlld'
+
+
+class ConstructResultCsvFacet(RichFacet):
+    """Render CONSTRUCT query results as CSV."""
+
+    META = META
+
+    def show(self) -> Renderable:
+        """Render Graph (CONSTRUCT result) as CSV."""
+        if not isinstance(self.this, Literal):
+            raise NotALiteral(node=self.this)
+
+        graph = cast(Graph, self.this.value)
+
+        if not graph:
+            return ""
+
+        output = io.StringIO()
+        writer = csv.writer(output)
+        writer.writerow(('subject', 'predicate', 'object'))
+        writer.writerows(graph)
+
+        return output.getvalue()

--- a/iolanta/facets/query/construct_result_json.py
+++ b/iolanta/facets/query/construct_result_json.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+from typing import cast
+
+from rdflib import Graph, Literal
+
+from iolanta.facets.cli.base import Renderable, RichFacet
+from iolanta.facets.errors import NotALiteral
+
+META = Path(__file__).parent / 'data' / 'query_result.yamlld'
+
+
+class ConstructResultJsonFacet(RichFacet):
+    """Render CONSTRUCT query results as JSON."""
+
+    META = META
+
+    def show(self) -> Renderable:
+        """Render Graph (CONSTRUCT result) as JSON."""
+        if not isinstance(self.this, Literal):
+            raise NotALiteral(node=self.this)
+
+        graph = cast(Graph, self.this.value)
+        fieldnames = ('subject', 'predicate', 'object')
+        return json.dumps(
+            [
+                dict(zip(fieldnames, triple))
+                for triple in graph
+            ],
+            indent=2,
+            default=str,
+        )

--- a/iolanta/facets/query/construct_result_table.py
+++ b/iolanta/facets/query/construct_result_table.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+from typing import cast
+
+from more_itertools import consume
+from rdflib import Graph, Literal
+from rich.table import Table
+
+from iolanta.cli.formatters.pretty import pretty_print_value
+from iolanta.facets.cli.base import Renderable, RichFacet
+from iolanta.facets.errors import NotALiteral
+
+META = Path(__file__).parent / 'data' / 'query_result.yamlld'
+
+
+class ConstructResultTableFacet(RichFacet):
+    """Render CONSTRUCT query results as table."""
+
+    META = META
+
+    def show(self) -> Renderable:
+        """Render Graph (CONSTRUCT result) as table."""
+        if not isinstance(self.this, Literal):
+            raise NotALiteral(node=self.this)
+
+        graph = cast(Graph, self.this.value)
+
+        if not graph:
+            table = Table(
+                'Subject',
+                'Predicate',
+                'Object',
+                show_header=True,
+                header_style="bold magenta",
+            )
+            return table
+
+        table = Table(
+            'Subject',
+            'Predicate',
+            'Object',
+            show_header=True,
+            header_style="bold magenta",
+        )
+
+        consume(
+            table.add_row(
+                *[
+                    str(pretty_print_value(value))
+                    for value in triple
+                ],
+            )
+            for triple in graph
+        )
+
+        return table

--- a/iolanta/facets/query/data/query_result.yamlld
+++ b/iolanta/facets/query/data/query_result.yamlld
@@ -1,0 +1,102 @@
+"@context":
+  "@import": https://json-ld.org/contexts/dollar-convenience.jsonld
+  iolanta: https://iolanta.tech/
+  rdfs: "http://www.w3.org/2000/01/rdf-schema#"
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
+  owl: http://www.w3.org/2002/07/owl#
+
+  $: rdfs:label
+  →:
+    "@type": "@id"
+    "@id": iolanta:outputs
+  ⊆:
+    "@type": "@id"
+    "@id": rdfs:subClassOf
+  iolanta:hasDatatypeFacet:
+    "@type": "@id"
+
+$included:
+  # Define the three SPARQL result datatypes
+  - $id: https://iolanta.tech/datatypes/sparql-select-result
+    $type: owl:Class
+    ⊆: rdfs:Datatype
+    $: SPARQL SELECT Result
+    rdfs:comment: Datatype for SPARQL SELECT query results (variable bindings)
+
+  - $id: https://iolanta.tech/datatypes/sparql-construct-result
+    $type: owl:Class
+    ⊆: rdfs:Datatype
+    $: SPARQL CONSTRUCT Result
+    rdfs:comment: Datatype for SPARQL CONSTRUCT query results (RDF graph)
+
+  - $id: https://iolanta.tech/datatypes/sparql-ask-result
+    $type: owl:Class
+    ⊆: rdfs:Datatype
+    $: SPARQL ASK Result
+    rdfs:comment: Datatype for SPARQL ASK query results (boolean)
+
+  # Register SelectResult facets for each output format
+  - $id: pkg:pypi/iolanta#select-result-table-facet
+    $type: iolanta:Facet
+    $: SPARQL SELECT Result Table Facet
+    →: https://iolanta.tech/datatypes/table
+
+  - $id: pkg:pypi/iolanta#select-result-json-facet
+    $type: iolanta:Facet
+    $: SPARQL SELECT Result JSON Facet
+    →: https://iolanta.tech/datatypes/json
+
+  - $id: pkg:pypi/iolanta#select-result-csv-facet
+    $type: iolanta:Facet
+    $: SPARQL SELECT Result CSV Facet
+    →: https://iolanta.tech/datatypes/csv
+
+  - $id: https://iolanta.tech/datatypes/sparql-select-result
+    iolanta:hasDatatypeFacet:
+      - pkg:pypi/iolanta#select-result-table-facet
+      - pkg:pypi/iolanta#select-result-json-facet
+      - pkg:pypi/iolanta#select-result-csv-facet
+
+  # Register ConstructResult facets for each output format
+  - $id: pkg:pypi/iolanta#construct-result-table-facet
+    $type: iolanta:Facet
+    $: SPARQL CONSTRUCT Result Table Facet
+    →: https://iolanta.tech/datatypes/table
+
+  - $id: pkg:pypi/iolanta#construct-result-json-facet
+    $type: iolanta:Facet
+    $: SPARQL CONSTRUCT Result JSON Facet
+    →: https://iolanta.tech/datatypes/json
+
+  - $id: pkg:pypi/iolanta#construct-result-csv-facet
+    $type: iolanta:Facet
+    $: SPARQL CONSTRUCT Result CSV Facet
+    →: https://iolanta.tech/datatypes/csv
+
+  - $id: https://iolanta.tech/datatypes/sparql-construct-result
+    iolanta:hasDatatypeFacet:
+      - pkg:pypi/iolanta#construct-result-table-facet
+      - pkg:pypi/iolanta#construct-result-json-facet
+      - pkg:pypi/iolanta#construct-result-csv-facet
+
+  # Register AskResult facets for each output format
+  - $id: pkg:pypi/iolanta#ask-result-table-facet
+    $type: iolanta:Facet
+    $: SPARQL ASK Result Table Facet
+    →: https://iolanta.tech/datatypes/table
+
+  - $id: pkg:pypi/iolanta#ask-result-json-facet
+    $type: iolanta:Facet
+    $: SPARQL ASK Result JSON Facet
+    →: https://iolanta.tech/datatypes/json
+
+  - $id: pkg:pypi/iolanta#ask-result-csv-facet
+    $type: iolanta:Facet
+    $: SPARQL ASK Result CSV Facet
+    →: https://iolanta.tech/datatypes/csv
+
+  - $id: https://iolanta.tech/datatypes/sparql-ask-result
+    iolanta:hasDatatypeFacet:
+      - pkg:pypi/iolanta#ask-result-table-facet
+      - pkg:pypi/iolanta#ask-result-json-facet
+      - pkg:pypi/iolanta#ask-result-csv-facet

--- a/iolanta/facets/query/select_result_csv.py
+++ b/iolanta/facets/query/select_result_csv.py
@@ -1,0 +1,36 @@
+import csv
+import io
+from pathlib import Path
+
+from rdflib import Literal
+
+from iolanta.facets.cli.base import Renderable, RichFacet
+from iolanta.facets.errors import NotALiteral
+
+META = Path(__file__).parent / 'data' / 'query_result.yamlld'
+
+
+class SelectResultCsvFacet(RichFacet):
+    """Render SELECT query results as CSV."""
+
+    META = META
+
+    def show(self) -> Renderable:
+        """Render SelectResult as CSV."""
+        if not isinstance(self.this, Literal):
+            raise NotALiteral(node=self.this)
+
+        query_result = self.this.value
+
+        if not query_result:
+            return ""
+
+        output = io.StringIO()
+        first_row = query_result[0]
+        fieldnames = first_row.keys()
+
+        writer = csv.DictWriter(output, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(query_result)
+
+        return output.getvalue()

--- a/iolanta/facets/query/select_result_json.py
+++ b/iolanta/facets/query/select_result_json.py
@@ -1,0 +1,24 @@
+import json
+from pathlib import Path
+
+from rdflib import Literal
+
+from iolanta.facets.cli.base import Renderable, RichFacet
+from iolanta.facets.errors import NotALiteral
+
+META = Path(__file__).parent / 'data' / 'query_result.yamlld'
+
+
+class SelectResultJsonFacet(RichFacet):
+    """Render SELECT query results as JSON."""
+
+    META = META
+
+    def show(self) -> Renderable:
+        """Render SelectResult as JSON."""
+        if not isinstance(self.this, Literal):
+            raise NotALiteral(node=self.this)
+
+        query_result = self.this.value
+
+        return json.dumps(query_result, indent=2, default=str)

--- a/iolanta/facets/query/select_result_table.py
+++ b/iolanta/facets/query/select_result_table.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+from more_itertools import consume, first
+from rdflib import Literal
+from rich.table import Table
+
+from iolanta.cli.formatters.pretty import pretty_print_value
+from iolanta.facets.cli.base import Renderable, RichFacet
+from iolanta.facets.errors import NotALiteral
+
+META = Path(__file__).parent / 'data' / 'query_result.yamlld'
+
+
+class SelectResultTableFacet(RichFacet):
+    """Render SELECT query results as table."""
+
+    META = META
+
+    def show(self) -> Renderable:
+        """Render SelectResult as table."""
+        if not isinstance(self.this, Literal):
+            raise NotALiteral(node=self.this)
+
+        query_result = self.this.value
+
+        if not query_result:
+            table = Table(show_header=True, header_style="bold magenta")
+            return table
+
+        columns = first(query_result).keys()
+
+        table = Table(
+            *columns,
+            show_header=True,
+            header_style="bold magenta",
+        )
+
+        consume(
+            table.add_row(
+                *[
+                    str(pretty_print_value(value))
+                    for value in row.values()
+                ],
+            )
+            for row in query_result
+        )
+
+        return table

--- a/iolanta/mcp/cli.py
+++ b/iolanta/mcp/cli.py
@@ -1,6 +1,9 @@
+from pathlib import Path
 from typing import Annotated
 
 from fastmcp import FastMCP
+from rdflib import URIRef
+from yarl import URL
 
 from iolanta.cli.main import render_and_return
 
@@ -9,11 +12,21 @@ mcp = FastMCP("Iolanta MCP Server")
 
 @mcp.tool()
 def render_uri(
-    uri: Annotated[str, 'URL, or file system path, to render'],
-    as_format: Annotated[str, 'Format to render as. Examples: `labeled-triple-set`, `mermaid`'],
+    uri: Annotated[str, "URL, or file system path, to render"],
+    as_format: Annotated[
+        str, "Format to render as. Examples: `labeled-triple-set`, `mermaid`"
+    ],
 ) -> str:
     """Render a URI."""
-    return str(render_and_return(uri, as_format))
+    # Parse string URL to URIRef
+    node_url = URL(uri)
+    if node_url.scheme and node_url.scheme != "file":
+        node = URIRef(uri)
+    else:
+        path = Path(node_url.path).absolute()
+        node = URIRef(f"file://{path}")
+
+    return str(render_and_return(node=node, as_datatype=as_format))
 
 
 def app():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iolanta"
-version = "2.1.12"
+version = "2.1.13"
 description = "Semantic Web browser"
 authors = ["Anatoly Scherbakov <altaisoft@gmail.com>"]
 license = "MIT"
@@ -66,6 +66,15 @@ mermaid-graph = "iolanta.mermaid.facet:Mermaid"
 mermaid-roadmap = "iolanta.facets.mermaid_roadmap.facet:MermaidRoadmap"
 rich-declension-table = "iolanta.declension.facet:RichDeclensionTable"
 labeled-triple-set = "iolanta.labeled_triple_set.labeled_triple_set:LabeledTripleSet"
+select-result-table-facet = "iolanta.facets.query.select_result_table:SelectResultTableFacet"
+select-result-json-facet = "iolanta.facets.query.select_result_json:SelectResultJsonFacet"
+select-result-csv-facet = "iolanta.facets.query.select_result_csv:SelectResultCsvFacet"
+construct-result-table-facet = "iolanta.facets.query.construct_result_table:ConstructResultTableFacet"
+construct-result-json-facet = "iolanta.facets.query.construct_result_json:ConstructResultJsonFacet"
+construct-result-csv-facet = "iolanta.facets.query.construct_result_csv:ConstructResultCsvFacet"
+ask-result-table-facet = "iolanta.facets.query.ask_result_table:AskResultTableFacet"
+ask-result-json-facet = "iolanta.facets.query.ask_result_json:AskResultJsonFacet"
+ask-result-csv-facet = "iolanta.facets.query.ask_result_csv:AskResultCsvFacet"
 
 [tool.poetry.plugins."rdf.plugins.queryprocessor"]
 sparqlspace = "iolanta.sparqlspace.processor:GlobalSPARQLProcessor"


### PR DESCRIPTION
- **#XXX ➕ `facets.query` package with separate facet files for SPARQL result rendering**
- **#XXX Update entry points → `facets.query` & bump version 2.1.12 → 2.1.13**
- **#XXX Refactor `render_and_return()`: accept `Node`, extract helpers, use `match/case`, condense try blocks**
- **#XXX Update `render_uri()` to parse URL before calling `render_and_return()`**
- **#XXX ➕ Rules F05-F08 for code quality: condense try blocks, minimize try scope, remove unreachable branches, use match/case**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces first-class SPARQL result rendering and streamlines the CLI render pipeline.
> 
> - **New `facets.query`**: Facets for `SELECT`, `CONSTRUCT`, and `ASK` results with `table`/`json`/`csv` outputs; registers datatypes in `facets/query/data/query_result.yamlld`
> - **CLI enhancements (`iolanta/cli/main.py`)**: `--query` option executes SPARQL and renders results; `render_and_return(node, ...)` now accepts `Literal | URIRef`; new helpers `setup_logging`, `handle_error`, `create_query_node`; improved error handling and `match/case` usage
> - **MCP update (`iolanta/mcp/cli.py`)**: parses URIs to `URIRef` and calls updated `render_and_return`
> - **Packaging**: Registers new facet entry points; bumps version `2.1.12` → `2.1.13`
> - **Docs**: Adds code-quality rules F05–F08 in `AGENTS.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb103bd580c452a6507d6040865ad819416d81b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->