### PR TITLE
Avoid `pyld` crash

### DIFF
--- a/iolanta/sparqlspace/processor.py
+++ b/iolanta/sparqlspace/processor.py
@@ -607,6 +607,9 @@ class GlobalSPARQLProcessor(Processor):  # noqa: WPS338, WPS214
         except HTTPError as http_error:
             self.logger.warning(f"{source} | HTTP error: {http_error}")
             return Loaded()
+        except TypeError as type_error:
+            self.logger.error(f"{source} | JSON-LD type error: {type_error}")
+            return Loaded()
 
         try:
             quads = list(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iolanta"
-version = "2.1.21"
+version = "2.1.22"
 description = "Semantic Web browser"
 authors = ["Anatoly Scherbakov <altaisoft@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds a defensive `TypeError` catch around JSON-LD conversion and bumps the patch version. Behavior change is limited to error handling/logging during remote data loads.
> 
> **Overview**
> Prevents `GlobalSPARQLProcessor.load()` from crashing when `yaml_ld.to_rdf()` raises a `TypeError` (e.g., malformed/unsupported JSON-LD), by catching it, logging an explicit "JSON-LD type error", and treating the source as successfully handled (`Loaded()`).
> 
> Bumps the package version from `2.1.21` to `2.1.22`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5a01878c4dc76fa37c79782ca7eb025db445673. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->