### PR TITLE
369 httpsschemaorgcreativeworkseries has no title

### DIFF
--- a/iolanta/facets/textual_default/facets.py
+++ b/iolanta/facets/textual_default/facets.py
@@ -33,10 +33,10 @@ class Description(Static):
     """
 
 
-class TextualDefaultFacet(Facet[Widget]):   # noqa: WPS214
+class TextualDefaultFacet(Facet[Widget]):  # noqa: WPS214
     """Default rendering engine."""
 
-    query_file_name = 'properties.sparql'
+    query_file_name = "properties.sparql"
     properties_on_the_right = False
 
     @functools.cached_property
@@ -47,10 +47,7 @@ class TextualDefaultFacet(Facet[Widget]):   # noqa: WPS214
             this=self.this,
         )
 
-        property_pairs = [
-            (row['property'], row['object'])
-            for row in property_rows
-        ]
+        property_pairs = [(row["property"], row["object"]) for row in property_rows]
 
         iolanta_lang = str(self.iolanta.language)
         property_pairs = [
@@ -79,7 +76,9 @@ class TextualDefaultFacet(Facet[Widget]):   # noqa: WPS214
                     property_value=property_value,
                     subject=self.this,
                     property_iri=property_iri,
-                ) if isinstance(property_value, Literal) else PropertyValue(
+                )
+                if isinstance(property_value, Literal)
+                else PropertyValue(
                     property_value=property_value,
                     subject=self.this,
                     property_iri=property_iri,
@@ -130,26 +129,28 @@ class TextualDefaultFacet(Facet[Widget]):   # noqa: WPS214
 
         match literal_value:
             case str() as string:
-                return string
+                # Escape ALL square brackets - Rich's escape_markup only escapes
+                # lowercase tags, but [[ItemList]] etc. still cause MarkupError
+                return string.replace("[", r"\[")
 
             case minidom.Document() as xml_document:
                 return Syntax(
                     xml_document.toxml(),
-                    'xml',
+                    "xml",
                 )
 
             case something_else:
                 type_of_something_else = type(something_else)
                 raise ValueError(
-                    f'What is this? {something_else} '   # noqa: WPS326
-                    f'is a {type_of_something_else}!',   # noqa: WPS326
+                    f"What is this? {something_else} "  # noqa: WPS326
+                    f"is a {type_of_something_else}!",  # noqa: WPS326
                 )
 
     @functools.cached_property
     def properties(self) -> Widget | None:
         """Render properties table."""
         if not self.grouped_properties:
-            return Static('No properties found ☹')
+            return Static("No properties found ☹")
 
         return PropertiesContainer(*self.rows)
 
@@ -160,7 +161,7 @@ class TextualDefaultFacet(Facet[Widget]):   # noqa: WPS214
 
         if self.description:
             widgets.append(Description(self.description))
-        
+
         widgets.append(self.properties)
 
         return VerticalScroll(*widgets)
@@ -176,11 +177,12 @@ class PageFooter(PageTitle):
     }
     """
 
+
 class InverseProperties(TextualDefaultFacet):
     """Inverse properties view."""
 
-    META = Path(__file__).parent / 'textual-inverse-properties.yamlld'
-    query_file_name = 'inverse-properties.sparql'
+    META = Path(__file__).parent / "textual-inverse-properties.yamlld"
+    query_file_name = "inverse-properties.sparql"
     properties_on_the_right = True
 
     def show(self) -> Widget:
@@ -189,5 +191,5 @@ class InverseProperties(TextualDefaultFacet):
             VerticalScroll(
                 self.properties,
             ),
-            PageFooter(self.this, extra='[i]& its inverse RDF properties[/i]'),
+            PageFooter(self.this, extra="[i]& its inverse RDF properties[/i]"),
         )

--- a/poetry.lock
+++ b/poetry.lock
@@ -4845,14 +4845,14 @@ dev = ["black (>=19.3b0) ; python_version >= \"3.6\"", "pytest (>=4.6.2)"]
 
 [[package]]
 name = "yaml-ld"
-version = "1.1.16"
+version = "1.1.17"
 description = "YAML-LD for Python"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "yaml_ld-1.1.16-py3-none-any.whl", hash = "sha256:fb04e3539b087addabd72169c8d09b9cbefb9f2d70ececd5917bd3b7d78ed25e"},
-    {file = "yaml_ld-1.1.16.tar.gz", hash = "sha256:fc2f1a28d5dfc61696b200f07f7ecde1f39d0417c21bdcec11f51bc1c0a24ba4"},
+    {file = "yaml_ld-1.1.17-py3-none-any.whl", hash = "sha256:02c5299b467bd75cf3da73416bd0222979ee1bf2303dee528da385a6666141c3"},
+    {file = "yaml_ld-1.1.17.tar.gz", hash = "sha256:b51a2d619945cdb1d1ac90af7bbca17abfc4505fb930ac54e7676ea08aa92998"},
 ]
 
 [package.dependencies]
@@ -4987,4 +4987,4 @@ all = []
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "c2dc8bc7f1afb8c2e722d1902d88300dc07812f10334cb4ced9b421d4f898212"
+content-hash = "cecf289b26b703d340b634fff8aba40c33386e0e3e169fbaf6dd799ea21ae925"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iolanta"
-version = "2.1.22"
+version = "2.1.23"
 description = "Semantic Web browser"
 authors = ["Anatoly Scherbakov <altaisoft@gmail.com>"]
 license = "MIT"
@@ -24,7 +24,7 @@ rich = ">=13.3.1"
 textual = ">=0.83.0"
 yarl = ">=1.9.4"
 boltons = ">=24.0.0"
-yaml-ld = ">=1.1.16"
+yaml-ld = ">=1.1.17"
 reasonable = ">=0.2.6"
 oxrdflib = ">=0.4.0"
 loguru = ">=0.7.3"


### PR DESCRIPTION
- **Bump**
- **Escape `rich` markup**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small UI rendering change to escape `[` in description strings plus a minor dependency/version bump; main risk is slight formatting changes to displayed text.
> 
> **Overview**
> Fixes a Rich/Textual rendering issue by escaping `[` in string descriptions returned by `TextualDefaultFacet.description`, preventing `MarkupError` when RDF text contains bracketed tokens.
> 
> Bumps the project version to `2.1.23` and updates the `yaml-ld` dependency/lock from `1.1.16` to `1.1.17` (plus associated lockfile hash updates).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44b1e9f0b92e06cc582f51547db7242870741c54. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->