### PR TITLE
handle sparql not exists

### DIFF
--- a/iolanta/sparqlspace/processor.py
+++ b/iolanta/sparqlspace/processor.py
@@ -88,15 +88,15 @@ def _extract_from_mapping(  # noqa: WPS213, WPS231
         case "Filter" | "UnaryNot" | "OrderCondition":
             yield from extract_mentioned_urls(algebra["expr"])  # noqa: WPS204, WPS226
 
-        case "Builtin_EXISTS":
-            # Builtin_EXISTS uses 'graph' instead of 'arg'
+        case "Builtin_EXISTS" | "Builtin_NOTEXISTS":
+            # Both use 'graph' instead of 'arg'
             yield from extract_mentioned_urls(algebra["graph"])
 
         case built_in if built_in.startswith("Builtin_"):
-            # Some built-ins may not have an 'arg' key
-            arg_value = algebra.get("arg")
-            if arg_value is not None:
-                yield from extract_mentioned_urls(arg_value)
+            # CompValue.get() returns the key name as default (not None),
+            # so use 'in' to check for key presence.
+            if "arg" in algebra:
+                yield from extract_mentioned_urls(algebra["arg"])   # noqa: WPS529
 
         case "RelationalExpression":
             yield from extract_mentioned_urls(algebra["expr"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iolanta"
-version = "2.1.23"
+version = "2.1.24"
 description = "Semantic Web browser"
 authors = ["Anatoly Scherbakov <altaisoft@gmail.com>"]
 license = "MIT"

--- a/tests/test_sparql_filter_not_exists.py
+++ b/tests/test_sparql_filter_not_exists.py
@@ -1,0 +1,29 @@
+"""Regression test: FILTER NOT EXISTS with property path triggers ValueError."""
+from pathlib import Path
+
+from rdflib import Namespace
+from rdflib.namespace import RDF, XSD
+from rdflib.plugins.sparql.algebra import translateQuery
+from rdflib.plugins.sparql.parser import parseQuery
+
+from iolanta.sparqlspace.processor import extract_mentioned_urls
+
+SPARQL_FILE = Path(__file__).parent / "tests.sparql"
+
+MF = Namespace("http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#")
+JLD = Namespace("https://json-ld.github.io/yaml-ld/tests/vocab#")
+
+NAMESPACES = {
+    "mf": MF,
+    "rdf": RDF,
+    "xsd": XSD,
+    "jld": JLD,
+}
+
+
+def test_extract_mentioned_urls_filter_not_exists():
+    """FILTER NOT EXISTS with property path must not raise ValueError."""
+    query_text = SPARQL_FILE.read_text()
+    parsed = parseQuery(query_text)
+    algebra = translateQuery(parsed, initNs=NAMESPACES).algebra
+    list(extract_mentioned_urls(algebra))

--- a/tests/tests.sparql
+++ b/tests/tests.sparql
@@ -1,0 +1,58 @@
+SELECT
+    ?manifest ?base_iri ?test ?result ?input ?req ?extract_all_scripts ?base
+    ?context ?frame ?redirect_to ?compact_arrays
+WHERE {
+    ?manifest mf:entries/rdf:rest*/rdf:first ?test .
+
+    ?test
+        a $test_class ;
+        mf:result ?result ;
+        mf:action ?input .
+
+    OPTIONAL {
+        ?manifest jld:baseIri ?base_iri .
+    }
+
+    OPTIONAL {
+        ?test jld:req ?req .
+    }
+
+    OPTIONAL {
+        ?test jld:option / jld:extractAllScripts ?extract_all_scripts .
+    }
+
+    OPTIONAL {
+        ?test jld:option / jld:base ?base .
+    }
+
+    OPTIONAL {
+        ?test jld:option / jld:redirectTo ?redirect_to .
+    }
+
+
+    OPTIONAL {
+        ?test jld:option / jld:compactArrays ?compact_arrays .
+    }
+
+    OPTIONAL {
+        ?test jld:context ?context .
+    }
+
+    OPTIONAL {
+        ?test jld:frame ?frame .
+    }
+
+    # FIXME: We mimic how `pyld` tests work, skipping 1.0 tests. This is probably incorrect though.
+    FILTER NOT EXISTS {
+        ?test jld:option / jld:specVersion "json-ld-1.0"^^xsd:string .
+    }
+
+    FILTER NOT EXISTS {
+        ?test jld:option / jld:processingMode "json-ld-1.0"^^xsd:string .
+    }
+
+    # Skip non-normative tests (Extended Profile); implementations may skip when asserting conformance.
+    FILTER NOT EXISTS {
+        ?test jld:option / jld:normative "false"^^xsd:boolean .
+    }
+}


### PR DESCRIPTION
- **SPARQL query from `python-yaml-ld` that triggers `ValueError` in `extract_mentioned_urls`**
- **Regression test: `FILTER NOT EXISTS` with property path must not raise `ValueError`**
- **Handle `Builtin_NOTEXISTS` & fix `CompValue.get()` default in `_extract_from_mapping`**
- **Bump version 2.1.23 → 2.1.24**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to SPARQL algebra URL extraction plus a regression test; primary risk is slight behavior change in which URLs are considered “mentioned” for certain SPARQL built-ins.
> 
> **Overview**
> Fixes `extract_mentioned_urls` to correctly traverse RDFlib algebra for `FILTER (NOT) EXISTS` by handling `Builtin_NOTEXISTS` (and treating both EXISTS variants as using `graph`), and avoids a `CompValue.get()` default-value pitfall by checking key presence with `"arg" in algebra`.
> 
> Adds a regression test and fixture SPARQL query exercising `FILTER NOT EXISTS` with property paths, and bumps the package version to `2.1.24`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9c9205a7d0d7594af2c6452d77443214a966fdb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->