### PR TITLE
upgrade rdflib to latest

### DIFF
--- a/iolanta/facets/mermaid_roadmap/facet.py
+++ b/iolanta/facets/mermaid_roadmap/facet.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 from typing import Iterable
 
-from rdflib import BNode, Literal, Node, URIRef
+from rdflib import BNode, Literal, URIRef
+from rdflib.term import Node
 
 from iolanta import Facet
 from iolanta.mermaid.models import (
@@ -10,12 +11,11 @@ from iolanta.mermaid.models import (
     MermaidEdge,
     MermaidLiteral,
     MermaidScalar,
-    MermaidSubgraph,
+    MermaidSubgraph,  # noqa: F401 - required for model_rebuild() namespace
     MermaidURINode,
 )
 from iolanta.namespaces import DATATYPES
 from pydantic import AnyUrl
-from rdflib import URIRef as RDFURIRef
 
 
 class TaskNode(MermaidScalar):
@@ -44,7 +44,7 @@ class BlocksEdge(MermaidEdge):
         super().__init__(
             source=source,
             target=target,
-            predicate=RDFURIRef('https://iolanta.tech/roadmap/blocks'),
+            predicate=URIRef('https://iolanta.tech/roadmap/blocks'),
             title='',
         )
 

--- a/iolanta/facets/textual_browser/page_switcher.py
+++ b/iolanta/facets/textual_browser/page_switcher.py
@@ -6,7 +6,8 @@ from dataclasses import dataclass
 from typing import Any
 
 import watchfiles
-from rdflib import BNode, Node, URIRef
+from rdflib import BNode, URIRef
+from rdflib.term import Node
 from textual.widgets import ContentSwitcher, RichLog
 from textual.worker import Worker, WorkerState
 

--- a/iolanta/facets/textual_graphs/facets.py
+++ b/iolanta/facets/textual_graphs/facets.py
@@ -3,7 +3,8 @@ from pathlib import Path
 from typing import Iterable, NamedTuple
 
 import funcy
-from rdflib import Literal, Node
+from rdflib import Literal
+from rdflib.term import Node
 from textual.containers import Vertical
 from textual.coordinate import Coordinate
 from textual.widgets import DataTable

--- a/iolanta/facets/textual_property_pairs_table.py
+++ b/iolanta/facets/textual_property_pairs_table.py
@@ -2,7 +2,8 @@ from collections import defaultdict
 from typing import Iterable
 
 import funcy
-from rdflib import Literal, Node
+from rdflib import Literal
+from rdflib.term import Node
 from rich.style import Style
 from rich.text import Text
 from textual.containers import Vertical

--- a/iolanta/kglint/facet.py
+++ b/iolanta/kglint/facet.py
@@ -4,7 +4,8 @@ import re
 from pathlib import Path
 
 import funcy
-from rdflib import BNode, Literal, Node, URIRef
+from rdflib import BNode, Literal, URIRef
+from rdflib.term import Node
 
 from iolanta import Facet
 from iolanta.kglint.models import (
@@ -20,7 +21,7 @@ from iolanta.kglint.models import (
 )
 from iolanta.namespaces import DATATYPES
 
-QNAME_RE = re.compile(r'^\S+:\S+$')
+QNAME_RE = re.compile(r"^\S+:\S+$")
 
 
 def _serialize(node: Node) -> str:

--- a/iolanta/labeled_triple_set/labeled_triple_set.py
+++ b/iolanta/labeled_triple_set/labeled_triple_set.py
@@ -2,16 +2,9 @@ from pathlib import Path
 from typing import Annotated, Iterable
 from typing import Literal as TypingLiteral
 
-from pydantic import (
-    AnyUrl,
-    BaseModel,
-    Field,
-    TypeAdapter,
-    field_serializer,
-    field_validator,
-    validator,
-)
-from rdflib import BNode, Literal, Node, URIRef
+from pydantic import AnyUrl, BaseModel, Field, TypeAdapter
+from rdflib import BNode, Literal, URIRef
+from rdflib.term import Node
 
 from iolanta import Facet
 from iolanta.models import NotLiteralNode

--- a/iolanta/mermaid/facet.py
+++ b/iolanta/mermaid/facet.py
@@ -2,12 +2,10 @@ import functools
 from pathlib import Path
 from typing import Iterable
 
-import boltons
-import cachetools
 import funcy
-from boltons.cacheutils import cached, cachedmethod
 from pydantic import AnyUrl
-from rdflib import BNode, Literal, Node, URIRef
+from rdflib import BNode, Literal, URIRef
+from rdflib.term import Node
 
 from iolanta import Facet
 from iolanta.mermaid.models import (

--- a/iolanta/sparqlspace/cli.py
+++ b/iolanta/sparqlspace/cli.py
@@ -2,7 +2,7 @@ from enum import StrEnum
 from typing import Annotated
 
 import rich
-from rdflib import Node
+from rdflib.term import Node
 from rdflib.query import Result
 from rich.table import Table
 from typer import Option, Typer

--- a/poetry.lock
+++ b/poetry.lock
@@ -3603,14 +3603,14 @@ pyyaml = "*"
 
 [[package]]
 name = "rdflib"
-version = "7.1.3"
+version = "7.6.0"
 description = "RDFLib is a Python library for working with RDF, a simple yet powerful language for representing information."
 optional = false
-python-versions = "<4.0.0,>=3.8.1"
+python-versions = ">=3.8.1"
 groups = ["main"]
 files = [
-    {file = "rdflib-7.1.3-py3-none-any.whl", hash = "sha256:5402310a9f0f3c07d453d73fd0ad6ba35616286fe95d3670db2b725f3f539673"},
-    {file = "rdflib-7.1.3.tar.gz", hash = "sha256:f3dcb4c106a8cd9e060d92f43d593d09ebc3d07adc244f4c7315856a12e383ee"},
+    {file = "rdflib-7.6.0-py3-none-any.whl", hash = "sha256:30c0a3ebf4c0e09215f066be7246794b6492e054e782d7ac2a34c9f70a15e0dd"},
+    {file = "rdflib-7.6.0.tar.gz", hash = "sha256:6c831288d5e4a5a7ece85d0ccde9877d512a3d0f02d7c06455d00d6d0ea379df"},
 ]
 
 [package.dependencies]
@@ -3619,10 +3619,12 @@ pyparsing = ">=2.1.0,<4"
 
 [package.extras]
 berkeleydb = ["berkeleydb (>=18.1.0,<19.0.0)"]
+graphdb = ["httpx (>=0.28.1,<0.29.0)"]
 html = ["html5rdf (>=1.2,<2)"]
 lxml = ["lxml (>=4.3,<6.0)"]
 networkx = ["networkx (>=2,<4)"]
 orjson = ["orjson (>=3.9.14,<4)"]
+rdf4j = ["httpx (>=0.28.1,<0.29.0)"]
 
 [[package]]
 name = "rdflib-pyld-compat"
@@ -4987,4 +4989,4 @@ all = []
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "cecf289b26b703d340b634fff8aba40c33386e0e3e169fbaf6dd799ea21ae925"
+content-hash = "0c017481f68cdec0ca8383a8df928ea9530862749ed7e8e515ba7984acad48ca"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iolanta"
-version = "2.1.24"
+version = "2.1.25"
 description = "Semantic Web browser"
 authors = ["Anatoly Scherbakov <altaisoft@gmail.com>"]
 license = "MIT"
@@ -9,7 +9,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
 jinja2 = ">=3.1.0"
-rdflib = "<8.0"
+rdflib = ">=7.6.0,<8.0"
 python-frontmatter = ">=0.5.0"
 requests = ">=2.25.1"
 deepmerge = ">=0.1.1"


### PR DESCRIPTION
- **Bump version 2.1.24 → 2.1.25, require `rdflib` >=7.6.0,<8.0**
- **Regenerate lockfile for `rdflib` 7.6.0**
- **Import `Node` from `rdflib.term` instead of `rdflib`**
- **Import `Node` from `rdflib.term` instead of `rdflib`**
- **Import `Node` from `rdflib.term` instead of `rdflib`**
- **Import `Node` from `rdflib.term` instead of `rdflib`**
- **Import `Node` from `rdflib.term` instead of `rdflib`**
- **Import `Node` from `rdflib.term`, 🧹 unused pydantic imports**
- **Import `Node` from `rdflib.term`, 🧹 unused `boltons` and `cachetools` imports**
- **Import `Node` from `rdflib.term`, 🧹 redundant `RDFURIRef` alias**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades the core RDF dependency (`rdflib`) and adjusts imports/types accordingly, which could surface behavioral or compatibility issues in RDF parsing/serialization paths. Code changes are otherwise mostly mechanical cleanups.
> 
> **Overview**
> Upgrades `rdflib` to `7.6.0` (and bumps project version to `2.1.25`), updating `pyproject.toml` constraints and regenerating `poetry.lock`.
> 
> Updates multiple facets/CLI modules to import `Node` from `rdflib.term` (instead of `rdflib`) and removes a few now-unnecessary imports/aliases (e.g., redundant `URIRef` aliasing, unused `pydantic`/`boltons`/`cachetools` imports), including a small tweak in `mermaid_roadmap` to keep `MermaidSubgraph` in scope for Pydantic model rebuilds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 792f93d4772fd1f8e96d42d97393c4c859936cde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->