### PR TITLE
hanging on urls without linked data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,8 @@
 
 **F08.** Multiple if...elif branches with `isinstance()` calls must be replaced with `match/case` statements. The `match/case` syntax (Python 3.10+) is more readable, type-safe, and idiomatic for type-based dispatch. Use `match value: case Type():` instead of `if isinstance(value, Type): ... elif isinstance(value, OtherType): ...`.
 
+**F09.** In tests, prefer repeated string literals over helper constants introduced only to satisfy string-reuse lint rules. If satisfying a lint rule would require structural refactoring, API changes, or other non-local reshaping, stop and ask first. In tests, prefer a targeted `# noqa` over abstractions created only to silence the linter.
+
 ## Adding Jeeves Commands
 
 **J00.** Jeeves is a task runner based on Typer. To add a new development command, add a function to `jeeves/__init__.py`. Functions in this module automatically become commands accessible via `j <command-name>`.

--- a/iolanta/cli/main.py
+++ b/iolanta/cli/main.py
@@ -17,7 +17,6 @@ from yarl import URL
 from iolanta.cli.models import LogLevel
 from iolanta.facets.errors import FacetNotFound
 from iolanta.iolanta import Iolanta
-from iolanta.models import NotLiteralNode
 from iolanta.namespaces import DATATYPES
 from iolanta.query_result import (
     QueryResult,
@@ -32,22 +31,6 @@ console = Console()
 
 
 app = Typer(no_args_is_help=True)
-
-
-def string_to_node(name: str) -> NotLiteralNode:
-    """
-    Parse a string into a node identifier.
-
-    String might be:
-      * a URL,
-      * or a local disk path.
-    """
-    url = URL(name)
-    if url.scheme:
-        return URIRef(name)
-
-    path = Path(name).absolute()
-    return URIRef(f"file://{path}")
 
 
 def decode_datatype(datatype: str) -> URIRef:
@@ -160,6 +143,18 @@ def create_query_node(query_result: QueryResult) -> Literal:
             )
 
 
+def print_renderable(renderable) -> None:
+    match renderable:
+        case Table() as table:
+            console.print(table)
+        case str() as text:
+            sys.stdout.write(text)
+            if not text.endswith("\n"):
+                sys.stdout.write("\n")
+        case unknown:
+            console.print(unknown)
+
+
 def render_and_return(
     node: Literal | URIRef,
     as_datatype: str,
@@ -258,13 +253,7 @@ def render_command(  # noqa: WPS231, WPS238, WPS210, C901
         except Exception as error:
             handle_error(error, log_level, use_markdown=False)
         else:
-            # FIXME: An intermediary Literal can be used to dispatch rendering.
-            match renderable:
-                case Table() as table:
-                    console.print(table)
-
-                case unknown:
-                    console.print(unknown)
+            print_renderable(renderable)
         return
 
     if url is None:
@@ -295,10 +284,4 @@ def render_command(  # noqa: WPS231, WPS238, WPS210, C901
     except Exception as error:
         handle_error(error, log_level, use_markdown=False)
     else:
-        # FIXME: An intermediary Literal can be used to dispatch rendering.
-        match renderable:
-            case Table() as table:
-                console.print(table)
-
-            case unknown:
-                console.print(unknown)
+        print_renderable(renderable)

--- a/iolanta/sparqlspace/processor.py
+++ b/iolanta/sparqlspace/processor.py
@@ -3,6 +3,7 @@ import dataclasses
 import datetime
 from pathlib import Path
 from threading import Lock
+from types import MappingProxyType
 from typing import Any, Iterable, Mapping
 
 import funcy
@@ -183,14 +184,16 @@ def normalize_term(term: Node) -> Node:
     return term
 
 
-DCMI_NAMESPACE_DOCUMENTS = {
-    str(DC): URIRef(
-        "https://www.dublincore.org/specifications/dublin-core/dcmi-terms/dublin_core_elements.rdf",
-    ),
-    str(DCTERMS): URIRef(
-        "https://www.dublincore.org/specifications/dublin-core/dcmi-terms/dublin_core_terms.rdf",
-    ),
-}
+DCMI_NAMESPACE_DOCUMENTS = MappingProxyType(
+    {
+        str(DC): URIRef(
+            "https://www.dublincore.org/specifications/dublin-core/dcmi-terms/dublin_core_elements.rdf",
+        ),
+        str(DCTERMS): URIRef(
+            "https://www.dublincore.org/specifications/dublin-core/dcmi-terms/dublin_core_terms.rdf",
+        ),
+    }
+)
 
 
 def find_dcmi_namespace_document(source: URIRef) -> URIRef | None:
@@ -201,6 +204,21 @@ def find_dcmi_namespace_document(source: URIRef) -> URIRef | None:
             return document
 
     return None
+
+
+def _namespace_document_quads(
+    document_graph: Graph,
+    source_uri: URIRef,
+) -> list[tuple[Node, Node, Node, URIRef]]:
+    return [
+        (
+            normalize_term(subject),
+            normalize_term(predicate),
+            normalize_term(object_),
+            source_uri,
+        )
+        for subject, predicate, object_ in document_graph
+    ]
 
 
 def resolve_variables(
@@ -503,6 +521,18 @@ class GlobalSPARQLProcessor(Processor):  # noqa: WPS338, WPS214
             )
         )
 
+    def _mark_as_failed(self, source_uri: URIRef) -> Loaded:
+        self.graph.add(
+            (
+                source_uri,
+                RDF.type,
+                IOLANTA["failed"],
+                source_uri,
+            )
+        )
+        self._mark_as_loaded(source_uri)
+        return Loaded()
+
     def _follow_is_visualized_with_links(self, uri: URIRef):
         """Follow `dcterms:isReferencedBy` links."""
         triples = self.graph.triples((uri, DCTERMS.isReferencedBy, None))
@@ -529,15 +559,7 @@ class GlobalSPARQLProcessor(Processor):  # noqa: WPS338, WPS214
             )
             return Loaded()
 
-        quads = [
-            (
-                normalize_term(subject),
-                normalize_term(predicate),
-                normalize_term(object_),
-                source_uri,
-            )
-            for subject, predicate, object_ in document_graph
-        ]
+        quads = _namespace_document_quads(document_graph, source_uri)
         if quads:
             self.graph.addN(quads)
             self.graph.last_not_inferred_source = source_uri
@@ -639,7 +661,7 @@ class GlobalSPARQLProcessor(Processor):  # noqa: WPS338, WPS214
 
             return Loaded()
 
-        except NoLinkedDataFoundInHTML:
+        except (NoLinkedDataFoundInHTML, KeyError):
             dcmi_namespace_document = find_dcmi_namespace_document(source_uri)
             if dcmi_namespace_document is not None:
                 self.logger.info(
@@ -648,32 +670,11 @@ class GlobalSPARQLProcessor(Processor):  # noqa: WPS338, WPS214
                     dcmi_namespace_document,
                 )
                 return self._load_dcmi_namespace_document(source_uri)
-
-            raise
-        except KeyError:
-            dcmi_namespace_document = find_dcmi_namespace_document(source_uri)
-            if dcmi_namespace_document is not None:
-                self.logger.info(
-                    "Redirecting %s → namespace document %s",
-                    source,
-                    dcmi_namespace_document,
-                )
-                return self._load_dcmi_namespace_document(source_uri)
-
-            raise
+            self.logger.info("%s | Failed to resolve linked data document", source)
+            return self._mark_as_failed(source_uri)
         except Exception as err:
             self.logger.info(f"{source} | Failed: {err}")
-            self.graph.add(
-                (
-                    URIRef(source),
-                    RDF.type,
-                    IOLANTA["failed"],
-                    source_uri,
-                )
-            )
-            self._mark_as_loaded(source_uri)
-
-            return Loaded()
+            return self._mark_as_failed(source_uri)
 
         if resolved_source:
             resolved_source_uri_ref = URIRef(resolved_source)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iolanta"
-version = "2.1.27"
+version = "2.1.28"
 description = "Semantic Web browser"
 authors = ["Anatoly Scherbakov <altaisoft@gmail.com>"]
 license = "MIT"

--- a/tests/kglint/data/remote_no_ld.yamlld
+++ b/tests/kglint/data/remote_no_ld.yamlld
@@ -1,0 +1,7 @@
+"@context":
+  ex: http://example.org/
+  schema: https://schema.org/
+
+"@id": ex:Person
+schema:url:
+  "@id": https://example.com/no-ld

--- a/tests/kglint/test_cli.py
+++ b/tests/kglint/test_cli.py
@@ -1,22 +1,92 @@
 """CLI alias test for kglint/json."""
 
+import functools
 import json
 from pathlib import Path
 
+import pytest
+import yaml_ld
 from rdflib import URIRef
+from typer.testing import CliRunner
+from yaml_ld.errors import NoLinkedDataFoundInHTML
 
+from iolanta.cli import main as cli_main
+from iolanta.cli.main import app
 from iolanta.cli.main import render_and_return
+from iolanta.sparqlspace import processor
 
-FIXTURES_DIR = Path(__file__).parent / 'data'
+FIXTURES_DIR = Path(__file__).parent / "data"
+
+
+def _skip_indices(sparql_processor):
+    sparql_processor.graph
+
+
+def _load_document_with_missing_ld(
+    uri,
+    *,
+    original_load_document,
+):
+    if str(uri) == "https://example.com/no-ld":
+        raise NoLinkedDataFoundInHTML(
+            "No linked data fragments found in HTML",
+        )
+    return original_load_document(uri)
+
+
+@pytest.fixture(autouse=True)
+def writable_log_path(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        cli_main.platformdirs,
+        "user_log_path",
+        lambda *args, **kwargs: tmp_path,
+    )
 
 
 def test_cli_kglint_json():
     """CLI with --as kglint/json returns valid JSON with assertions and labels."""
-    path = (FIXTURES_DIR / 'clean.yamlld').resolve()
-    node = URIRef(f'file://{path}')
-    raw = render_and_return(node=node, as_datatype='kglint/json')
+    path = (FIXTURES_DIR / "clean.yamlld").resolve()
+    node = URIRef(f"file://{path}")
+    raw = render_and_return(node=node, as_datatype="kglint/json")
     report = json.loads(raw)
-    assert 'assertions' in report
-    assert 'labels' in report
-    assert isinstance(report['assertions'], list)
-    assert isinstance(report['labels'], list)
+    assert "assertions" in report  # noqa: WPS226
+    assert "labels" in report  # noqa: WPS226
+    assert isinstance(report["assertions"], list)
+    assert isinstance(report["labels"], list)
+
+
+def test_cli_command_outputs_valid_json():
+    runner = CliRunner()
+    command_result = runner.invoke(
+        app,
+        ["tests/kglint/data/clean.yamlld", "--as", "kglint/json"],
+    )
+    report = json.loads(command_result.stdout)
+
+    assert command_result.exit_code == 0
+    assert "assertions" in report  # noqa: WPS226
+    assert "labels" in report  # noqa: WPS226
+
+
+def test_cli_missing_ld(monkeypatch):
+    path = (FIXTURES_DIR / "remote_no_ld.yamlld").resolve()
+    node = URIRef(f"file://{path}")
+    monkeypatch.setattr(
+        processor.GlobalSPARQLProcessor,
+        "_maybe_load_indices",
+        _skip_indices,
+    )
+    monkeypatch.setattr(
+        processor.yaml_ld,
+        "load_document",
+        functools.partial(
+            _load_document_with_missing_ld,
+            original_load_document=yaml_ld.load_document,
+        ),
+    )
+
+    raw = render_and_return(node=node, as_datatype="kglint/json")
+    report = json.loads(raw)
+
+    assert "assertions" in report
+    assert "labels" in report

--- a/tests/loaders/test_processor.py
+++ b/tests/loaders/test_processor.py
@@ -1,0 +1,31 @@
+from rdflib import ConjunctiveGraph, URIRef
+from yaml_ld.errors import NoLinkedDataFoundInHTML
+
+from iolanta.namespaces import IOLANTA
+from iolanta.sparqlspace import processor
+from iolanta.sparqlspace.processor import GlobalSPARQLProcessor, Loaded
+
+
+def test_no_linked_data_html_is_marked_failed_and_not_retried(monkeypatch):
+    source = URIRef('https://example.com/no-ld')
+    calls = 0
+
+    def fake_load_document(uri):
+        nonlocal calls
+        calls += 1
+        raise NoLinkedDataFoundInHTML('No linked data fragments found in HTML')
+
+    monkeypatch.setattr(processor.yaml_ld, 'load_document', fake_load_document)
+
+    sparql_processor = GlobalSPARQLProcessor(graph=ConjunctiveGraph())
+
+    assert isinstance(sparql_processor.load(source), Loaded)
+    assert isinstance(sparql_processor.load(source), processor.Skipped)
+    assert calls == 1
+    assert sparql_processor._is_loaded(source)
+    assert (
+        source,
+        processor.RDF.type,
+        IOLANTA['failed'],
+        source,
+    ) in sparql_processor.graph


### PR DESCRIPTION
- **Document F09 guidance on tests, string literals, and targeted noqa**
- **Add `print_renderable` for plain string output and remove `string_to_node`**
- **Mark `load` failed when document lacks linked data; factor `_mark_as_failed` and DCMI quads helper**
- **Bump version `2.1.27` → `2.1.28`**
- **➕ KGLint fixture with remote URL that has no embedded linked data**
- **Add Typer CLI and missing-LD `kglint/json` tests with writable log path fixture**
- **➕ Test `GlobalSPARQLProcessor.load` marks `NoLinkedDataFoundInHTML` once and skips retry**
