### PR TITLE
#381 Render Wikidata direct property titles

### DIFF
--- a/iolanta/sparqlspace/inference/wikidata-prop-label.sparql
+++ b/iolanta/sparqlspace/inference/wikidata-prop-label.sparql
@@ -5,6 +5,12 @@ CONSTRUCT {
 }
 WHERE {
   ?entity
-    (wikibase:claim | wikibase:qualifier | wikibase:statementProperty | wikibase:statementValueNormalized) ?thing ;
+    (
+      wikibase:claim
+      | wikibase:directClaim
+      | wikibase:qualifier
+      | wikibase:statementProperty
+      | wikibase:statementValueNormalized
+    ) ?thing ;
     rdfs:label ?label .
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iolanta"
-version = "2.1.28"
+version = "2.1.29"
 description = "Semantic Web browser"
 authors = ["Anatoly Scherbakov <altaisoft@gmail.com>"]
 license = "MIT"

--- a/tests/test_wikidata_label.py
+++ b/tests/test_wikidata_label.py
@@ -38,3 +38,15 @@ def test_wikidata_rhysling_title_bare_host_no_www():
     assert rendered_output == "Rhysling", (
         f"Expected 'Rhysling', got '{rendered_output}'"
     )
+
+
+def test_wikidata_direct_property_title():
+    """Wikidata direct property IRIs render their human-readable label."""
+    iolanta = Iolanta()
+    rendered_output = iolanta.render(
+        URIRef("http://www.wikidata.org/prop/direct/P397"),
+        as_datatype=DATATYPES.title,
+    )
+    assert rendered_output == "parent astronomical body", (
+        f"Expected 'parent astronomical body', got '{rendered_output}'"
+    )


### PR DESCRIPTION
## What changed

This fixes title rendering for Wikidata direct-property IRIs such as `http://www.wikidata.org/prop/direct/P397`.

The Wikidata property-label inference now propagates labels through `wikibase:directClaim`, so direct-property IRIs receive inferred `rdfs:label` values.

A regression test was added for `wdt:P397`, and the package version was bumped from `2.1.28` to `2.1.29`.

## Root cause

The title facet already checked `rdfs:label`, but `wdt:*` property IRIs were never getting one.

Wikidata JSON-LD stores the human-readable property label on the property entity IRI, while Iolanta relied on inference to copy that label onto related property IRIs. That inference covered claim and qualifier IRIs but missed `wikibase:directClaim`, so `--as title` fell back to the raw URI for direct-property IRIs.

## Impact

Commands like:

`iolanta http://www.wikidata.org/prop/direct/P397 --as title`

now resolve to a human-readable label instead of echoing the IRI.

## Validation

`pytest -q tests/test_wikidata_label.py`