### PR TITLE
[codex] Make graph triples view more concise

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,6 +3,7 @@ per-file-ignores =
     iolanta/facets/textual_ontology/facets.py:WPS201
     iolanta/cli/main.py:WPS201,WPS202
     iolanta/sparqlspace/processor.py:WPS201,WPS202,WPS402
+    iolanta/namespaces.py:WPS115,WPS604
     jeeves/__init__.py:WPS412,WPS400,WPS202
     tests/test_integration.py:WPS202
     tests/kglint/test_cli.py:WPS202

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,8 @@
 
 **F11.** Use `frozenset(("a", "b", ...))` with a tuple literal, not `frozenset({"a", "b", ...})` with a set literal. The set-literal form triggers WPS527.
 
+**F12.** After changing Python code, run `j fmt` and then `j lint`. Fix lint findings in touched files before reporting completion; if `j lint` still fails because of unrelated project-wide errors, report that clearly.
+
 ## Adding Jeeves Commands
 
 **J00.** Jeeves is a task runner based on Typer. To add a new development command, add a function to `jeeves/__init__.py`. Functions in this module automatically become commands accessible via `j <command-name>`.

--- a/iolanta/facets/prov_value_title/__init__.py
+++ b/iolanta/facets/prov_value_title/__init__.py
@@ -1,0 +1,3 @@
+from iolanta.facets.prov_value_title.facet import ProvValueTitle
+
+__all__ = ["ProvValueTitle"]

--- a/iolanta/facets/prov_value_title/facet.py
+++ b/iolanta/facets/prov_value_title/facet.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+import funcy
+from rdflib import URIRef
+
+from iolanta import Facet
+from iolanta.namespaces import DATATYPES
+
+
+class ProvValueTitle(Facet[str]):
+    """Title for provenance-qualified values."""
+
+    META = Path(__file__).parent / "prov_value_title.yamlld"
+
+    def show(self) -> str:
+        """Render a value with its source."""
+        row = funcy.first(
+            self.stored_query(
+                "title.sparql",
+                node=self.this,
+                language=self.language,
+            ),
+        )
+
+        if row is None:
+            return str(
+                self.render(
+                    self.this,
+                    as_datatype=URIRef("https://iolanta.tech/qname"),
+                ),
+            )
+
+        value_title = self.render(row["value"], as_datatype=DATATYPES.title)
+        source_title = self.render(row["source"], as_datatype=DATATYPES.title)
+        return f"{value_title} ⇐ {source_title}"

--- a/iolanta/facets/prov_value_title/prov_value_title.yamlld
+++ b/iolanta/facets/prov_value_title/prov_value_title.yamlld
@@ -1,0 +1,31 @@
+"@context":
+  "@import": https://json-ld.org/contexts/dollar-convenience.jsonld
+  iolanta: https://iolanta.tech/
+  prov: http://www.w3.org/ns/prov#
+  rdfs: http://www.w3.org/2000/01/rdf-schema#
+
+  $: rdfs:label
+  →:
+    "@type": "@id"
+    "@id": iolanta:outputs
+  ↦: iolanta:matches
+  ⪯:
+    "@type": "@id"
+    "@id": iolanta:is-preferred-over
+
+$id: pkg:pypi/iolanta#title-prov-value
+$: PROV Value Title
+→: https://iolanta.tech/datatypes/title
+⪯: pkg:pypi/iolanta#title
+
+↦: |
+  PREFIX prov: <http://www.w3.org/ns/prov#>
+
+  ASK WHERE {
+    $this
+      prov:value ?value ;
+      prov:wasDerivedFrom ?source .
+
+    FILTER (!isLiteral(?value) || !lang(?value) || lang(?value) = $language)
+    FILTER (!isLiteral(?source) || !lang(?source) || lang(?source) = $language)
+  }

--- a/iolanta/facets/prov_value_title/sparql/title.sparql
+++ b/iolanta/facets/prov_value_title/sparql/title.sparql
@@ -1,0 +1,11 @@
+PREFIX prov: <http://www.w3.org/ns/prov#>
+
+SELECT ?value ?source WHERE {
+    $node
+        prov:value ?value ;
+        prov:wasDerivedFrom ?source .
+
+    FILTER (!isLiteral(?value) || !lang(?value) || lang(?value) = $language)
+    FILTER (!isLiteral(?source) || !lang(?source) || lang(?source) = $language)
+}
+ORDER BY ?value ?source

--- a/iolanta/facets/textual_graph_triples.py
+++ b/iolanta/facets/textual_graph_triples.py
@@ -1,44 +1,45 @@
-from typing import Iterable
+from collections.abc import Callable, Iterable, Mapping
+from typing import cast
 
 import funcy
-from rdflib.term import Literal, Node
+from rdflib.term import Literal, Node, URIRef
 from textual.containers import Horizontal, Vertical
 from textual.widget import Widget
 
 from iolanta import Facet
 from iolanta.facets.textual_nanopublication.term_widget import TermWidget
-from iolanta.models import Triple
+from iolanta.models import NotLiteralNode, Triple
+from iolanta.namespaces import DATATYPES
 from iolanta.widgets.mixin import IolantaWidgetMixin
 
-BACKGROUND_COLORS = [    # noqa: WPS407
+BACKGROUND_COLORS = [  # noqa: WPS407
     # Let's honor 🇦🇲 flag!
-    'darkred',
-    'darkblue',
-    'darkorange',
-
-    'darkcyan',
-    'darkgoldenrod',
+    "darkred",
+    "darkblue",
+    "darkorange",
+    "darkcyan",
+    "darkgoldenrod",
     # 'darkgray',
-    'darkgreen',
+    "darkgreen",
     # 'darkgrey',
-    'darkkhaki',
-    'darkmagenta',
-    'darkolivegreen',
-    'darkorchid',
-    'darksalmon',
-    'darkseagreen',
+    "darkkhaki",
+    "darkmagenta",
+    "darkolivegreen",
+    "darkorchid",
+    "darksalmon",
+    "darkseagreen",
     # 'darkslateblue',
     # 'darkslategray',
     # 'darkslategrey',
-    'darkturquoise',
-    'darkviolet',
+    "darkturquoise",
+    "darkviolet",
 ]
 
 
 class TripleView(IolantaWidgetMixin, Horizontal):
     """Display a triple."""
 
-    DEFAULT_CSS = """
+    DEFAULT_CSS = """  # noqa: WPS115
     TripleView {
         padding-left: 0;
         padding-top: 0;
@@ -54,12 +55,12 @@ class TripleView(IolantaWidgetMixin, Horizontal):
     ):
         """Initialize."""
         self.triple = triple
-        self.color_per_node = color_per_node
+        self.color_per_node = color_per_node or {}
         super().__init__()
 
     def compose(self):
         """Render the triple."""
-        for term in self.triple:   # noqa: WPS526
+        for term in self.triple:  # noqa: WPS526
             yield TermWidget(
                 term,
                 background_color=self.color_per_node.get(term),
@@ -81,10 +82,21 @@ def construct_color_per_node(nodes: Iterable[Node]) -> dict[Node, str]:
     )
 
 
+def is_informative_triple(
+    triple: Triple,
+    render_title: Callable[[Node], object],
+) -> bool:
+    """Check whether a triple adds visible information to the graph view."""
+    if not isinstance(triple.object, Literal):
+        return True
+
+    return str(render_title(triple.subject)) != str(render_title(triple.object))
+
+
 class TriplesView(IolantaWidgetMixin, Vertical):
     """Display a set of triples."""
 
-    DEFAULT_CSS = """
+    DEFAULT_CSS = """  # noqa: WPS115
     TriplesView {
         padding: 1 2;
         height: auto;
@@ -95,17 +107,13 @@ class TriplesView(IolantaWidgetMixin, Vertical):
         """Initialize."""
         self.triples = triples
         self.color_per_node = construct_color_per_node(
-            [
-                term
-                for triple in triples
-                for term in triple
-            ],
+            [term for triple in triples for term in triple],
         )
         super().__init__()
 
     def compose(self):
         """Mount the triple stubs."""
-        for triple in self.triples:   # noqa: WPS526
+        for triple in self.triples:  # noqa: WPS526
             yield TripleView(triple, color_per_node=self.color_per_node)
 
     def on_mount(self):
@@ -114,14 +122,24 @@ class TriplesView(IolantaWidgetMixin, Vertical):
 
     def render_triples(self):
         """Render triples."""
-        term_view: TermWidget
-        triple_view: TripleView
-        for triple_view in self.children:
-            for term_view in triple_view.children:
-                term_view.renderable = self.iolanta.render(
-                    term_view.uri,
-                    as_datatype=term_view.as_datatype,
-                )
+        for term_view in self._term_widgets():
+            term_view.renderable = self.iolanta.render(
+                term_view.uri,
+                as_datatype=term_view.as_datatype,
+            )
+
+    def _triple_views(self) -> Iterable[TripleView]:
+        """Iterate over mounted triple views."""
+        for child in self.children:
+            if isinstance(child, TripleView):
+                yield child
+
+    def _term_widgets(self) -> Iterable[TermWidget]:
+        """Iterate over mounted term widgets."""
+        for triple_view in self._triple_views():
+            for child in triple_view.children:
+                if isinstance(child, TermWidget):
+                    yield child
 
 
 class GraphTriplesFacet(Facet[Widget]):
@@ -140,14 +158,28 @@ class GraphTriplesFacet(Facet[Widget]):
             """,
             graph=self.this,
         )
+        triple_rows = cast(Iterable[Mapping[str, Node]], rows)
 
         triples = [
             Triple(
-                subject=row['subject'],
-                predicate=row['predicate'],
-                object=row['object'],
+                subject=cast(NotLiteralNode, row["subject"]),
+                predicate=cast(NotLiteralNode, row["predicate"]),
+                object=cast(URIRef | Literal, row["object"]),
             )
-            for row in rows
+            for row in triple_rows
         ]
 
-        return TriplesView(triples)
+        informative_triples = [
+            triple
+            for triple in triples
+            if is_informative_triple(
+                triple=triple,
+                render_title=self._render_title,
+            )
+        ]
+
+        return TriplesView(informative_triples)
+
+    def _render_title(self, node: Node) -> object:
+        """Render node title."""
+        return self.render(node, as_datatype=DATATYPES.title)

--- a/iolanta/namespaces.py
+++ b/iolanta/namespaces.py
@@ -36,4 +36,4 @@ class XSD(rdflib.XSD):
 
 
 class PROV(rdflib.PROV):
-    _NS = rdflib.Namespace("https://www.w3.org/ns/prov#")
+    _NS = rdflib.Namespace("http://www.w3.org/ns/prov#")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iolanta"
-version = "2.1.32"
+version = "2.1.33"
 description = "Semantic Web browser"
 authors = ["Anatoly Scherbakov <altaisoft@gmail.com>"]
 license = "MIT"
@@ -63,6 +63,7 @@ textual-ontology = "iolanta.facets.textual_ontology:OntologyFacet"
 title = "iolanta.facets.title:TitleFacet"
 boolean = "iolanta.facets.generic:BoolLiteral"
 title-foaf-person = "iolanta.facets.foaf_person_title:FOAFPersonTitle"
+title-prov-value = "iolanta.facets.prov_value_title:ProvValueTitle"
 mermaid-graph = "iolanta.mermaid.facet:Mermaid"
 mermaid-nanopublication = "iolanta.facets.mermaid_nanopublication:NanopublicationMermaidFacet"
 mermaid-roadmap = "iolanta.facets.mermaid_roadmap.facet:MermaidRoadmap"

--- a/tests/facets/test_textual_graph_triples.py
+++ b/tests/facets/test_textual_graph_triples.py
@@ -1,0 +1,78 @@
+from collections.abc import Callable
+from typing import cast
+
+from rdflib import Literal, URIRef
+from rdflib.namespace import RDFS
+from rdflib.term import Node
+
+from iolanta.facets.textual_graph_triples import is_informative_triple
+from iolanta.models import Triple
+
+
+def test_redundant_literal_title_triple_is_hidden():
+    subject = URIRef('https://example.com/UTF-8')
+    triple = Triple(
+        subject=subject,
+        predicate=RDFS.label,
+        object=Literal('UTF-8'),
+    )
+
+    assert not is_informative_triple(
+        triple=triple,
+        render_title=cast(Callable[[Node], object], {
+            subject: 'UTF-8',
+            Literal('UTF-8'): 'UTF-8',
+        }.__getitem__),
+    )
+
+
+def test_different_literal_title_triple_is_kept():
+    subject = URIRef('https://example.com/UTF-8')
+    triple = Triple(
+        subject=subject,
+        predicate=RDFS.label,
+        object=Literal('Unicode UTF-8'),
+    )
+
+    assert is_informative_triple(
+        triple=triple,
+        render_title=cast(Callable[[Node], object], {
+            subject: 'UTF-8',
+            Literal('Unicode UTF-8'): 'Unicode UTF-8',
+        }.__getitem__),
+    )
+
+
+def test_iri_object_triple_is_kept_when_title_matches():
+    subject = URIRef('https://example.com/UTF-8')
+    object_ = URIRef('https://example.com/encoding/UTF-8')
+    triple = Triple(
+        subject=subject,
+        predicate=RDFS.seeAlso,
+        object=object_,
+    )
+
+    assert is_informative_triple(
+        triple=triple,
+        render_title=cast(Callable[[Node], object], {
+            subject: 'UTF-8',
+            object_: 'UTF-8',
+        }.__getitem__),
+    )
+
+
+def test_non_label_redundant_literal_title_triple_is_hidden():
+    subject = URIRef('https://example.com/UTF-8')
+    triple = Triple(
+        subject=subject,
+        predicate=RDFS.comment,
+        object=Literal('UTF-8'),
+    )
+
+    assert not is_informative_triple(
+        triple=triple,
+        render_title=cast(Callable[[Node], object], {
+            subject: 'UTF-8',
+            Literal('UTF-8'): 'UTF-8',
+        }.__getitem__),
+    )

--- a/tests/facets/test_textual_graph_triples.py
+++ b/tests/facets/test_textual_graph_triples.py
@@ -10,42 +10,48 @@ from iolanta.models import Triple
 
 
 def test_redundant_literal_title_triple_is_hidden():
-    subject = URIRef('https://example.com/UTF-8')
+    subject = URIRef("https://example.com/UTF-8")  # noqa: WPS226
     triple = Triple(
         subject=subject,
         predicate=RDFS.label,
-        object=Literal('UTF-8'),
+        object=Literal("UTF-8"),  # noqa: WPS226
     )
 
     assert not is_informative_triple(
         triple=triple,
-        render_title=cast(Callable[[Node], object], {
-            subject: 'UTF-8',
-            Literal('UTF-8'): 'UTF-8',
-        }.__getitem__),
+        render_title=cast(
+            Callable[[Node], object],
+            {
+                subject: "UTF-8",
+                Literal("UTF-8"): "UTF-8",
+            }.__getitem__,
+        ),
     )
 
 
 def test_different_literal_title_triple_is_kept():
-    subject = URIRef('https://example.com/UTF-8')
+    subject = URIRef("https://example.com/UTF-8")
     triple = Triple(
         subject=subject,
         predicate=RDFS.label,
-        object=Literal('Unicode UTF-8'),
+        object=Literal("Unicode UTF-8"),
     )
 
     assert is_informative_triple(
         triple=triple,
-        render_title=cast(Callable[[Node], object], {
-            subject: 'UTF-8',
-            Literal('Unicode UTF-8'): 'Unicode UTF-8',
-        }.__getitem__),
+        render_title=cast(
+            Callable[[Node], object],
+            {
+                subject: "UTF-8",
+                Literal("Unicode UTF-8"): "Unicode UTF-8",
+            }.__getitem__,
+        ),
     )
 
 
-def test_iri_object_triple_is_kept_when_title_matches():
-    subject = URIRef('https://example.com/UTF-8')
-    object_ = URIRef('https://example.com/encoding/UTF-8')
+def test_iri_object_title_match_is_kept():
+    subject = URIRef("https://example.com/UTF-8")  # noqa: WPS226
+    object_ = URIRef("https://example.com/encoding/UTF-8")
     triple = Triple(
         subject=subject,
         predicate=RDFS.seeAlso,
@@ -54,25 +60,31 @@ def test_iri_object_triple_is_kept_when_title_matches():
 
     assert is_informative_triple(
         triple=triple,
-        render_title=cast(Callable[[Node], object], {
-            subject: 'UTF-8',
-            object_: 'UTF-8',
-        }.__getitem__),
+        render_title=cast(
+            Callable[[Node], object],
+            {
+                subject: "UTF-8",
+                object_: "UTF-8",
+            }.__getitem__,
+        ),
     )
 
 
-def test_non_label_redundant_literal_title_triple_is_hidden():
-    subject = URIRef('https://example.com/UTF-8')
+def test_non_label_duplicate_literal_is_hidden():
+    subject = URIRef("https://example.com/UTF-8")  # noqa: WPS226
     triple = Triple(
         subject=subject,
         predicate=RDFS.comment,
-        object=Literal('UTF-8'),
+        object=Literal("UTF-8"),  # noqa: WPS226
     )
 
     assert not is_informative_triple(
         triple=triple,
-        render_title=cast(Callable[[Node], object], {
-            subject: 'UTF-8',
-            Literal('UTF-8'): 'UTF-8',
-        }.__getitem__),
+        render_title=cast(
+            Callable[[Node], object],
+            {
+                subject: "UTF-8",
+                Literal("UTF-8"): "UTF-8",
+            }.__getitem__,
+        ),
     )

--- a/tests/test_title.py
+++ b/tests/test_title.py
@@ -1,15 +1,17 @@
 import pytest
-from rdflib import URIRef
+from rdflib import BNode, Literal, URIRef
+from rdflib.namespace import RDFS
 
+from iolanta.facets.prov_value_title import ProvValueTitle
 from iolanta.facets.locator import FacetFinder
 from iolanta.iolanta import Iolanta
-from iolanta.namespaces import DATATYPES
+from iolanta.namespaces import DATATYPES, PROV
 
 
 @pytest.mark.parametrize(
     ("url", "expected_title"),
     [
-        ("http://purl.org/dc/elements/1.1/title", "Title"),
+        ("http://purl.org/dc/elements/1.1/title", "Title"),  # noqa: WPS226
         ("https://purl.org/dc/elements/1.1/title", "Title"),
         ("http://purl.org/dc/terms/title", "Title"),
         ("https://purl.org/dc/terms/title", "Title"),
@@ -42,3 +44,64 @@ def test_orcid_title_uses_person_title_facet():
     ).facet_and_output_datatype
 
     assert str(facet["facet"]) == "pkg:pypi/iolanta#title-foaf-person"
+
+
+def test_prov_value_title_renders_source():
+    """PROV value blank nodes should render as value sourced from reference."""
+    iolanta = Iolanta()
+    node = BNode()
+    source = URIRef("https://example.com/rfc-8259-section-8-1")
+    iolanta.graph.add((node, PROV.value, Literal(True)))
+    iolanta.graph.add((node, PROV.wasDerivedFrom, source))
+    iolanta.graph.add((source, RDFS.label, Literal("RFC 8259 section 8.1")))
+
+    rendered_output = ProvValueTitle(
+        this=node,
+        iolanta=iolanta,
+        as_datatype=DATATYPES.title,
+    ).show()
+
+    assert rendered_output == "true ⇐ RFC 8259 section 8.1"
+
+
+def test_prov_value_title_filters_by_language():
+    """PROV value titles should follow the configured output language."""
+    iolanta = Iolanta(language=Literal("en"))
+    node = BNode()
+    source = URIRef("https://example.com/source")
+    iolanta.graph.add((node, PROV.value, Literal("vrai", lang="fr")))
+    iolanta.graph.add((node, PROV.value, Literal("true", lang="en")))
+    iolanta.graph.add((node, PROV.wasDerivedFrom, source))
+    iolanta.graph.add((source, RDFS.label, Literal("Source anglaise", lang="fr")))
+    iolanta.graph.add((source, RDFS.label, Literal("English source", lang="en")))
+
+    rendered_output = ProvValueTitle(
+        this=node,
+        iolanta=iolanta,
+        as_datatype=DATATYPES.title,
+    ).show()
+
+    assert rendered_output == "true ⇐ English source"
+
+
+def test_prov_value_title_facet_is_selected():
+    """PROV value blank nodes should use the specialized title facet."""
+    iolanta = Iolanta()
+    iolanta.add(ProvValueTitle.META)
+    node = BNode()
+    iolanta.graph.add((node, PROV.value, Literal(True)))
+    iolanta.graph.add(
+        (
+            node,
+            PROV.wasDerivedFrom,
+            URIRef("https://example.com/rfc-8259-section-8-1"),
+        ),
+    )
+
+    facet = FacetFinder(
+        iolanta=iolanta,
+        node=node,
+        as_datatype=DATATYPES.title,
+    ).facet_and_output_datatype
+
+    assert str(facet["facet"]) == "pkg:pypi/iolanta#title-prov-value"


### PR DESCRIPTION
## Summary

- Hide redundant literal triples in the Graph Triples facet when the rendered object title duplicates the subject title.
- Add a specialized PROV value title facet so provenance-qualified blank nodes render as `{value} ⇐ {source}`.
- Standardize the PROV namespace on `http://www.w3.org/ns/prov#` and register the new title facet.

## Validation

- `poetry run pytest tests/test_title.py tests/facets/test_textual_graph_triples.py`
- `j fmt`
- `j lint` was run; it still reports existing project-wide type errors unrelated to this change set.