### PR TITLE
Update docs for visualization nanopub index discovery

### DIFF
--- a/docs/blog/publish-visualization-information-for-ontologies-on.md
+++ b/docs/blog/publish-visualization-information-for-ontologies-on.md
@@ -10,7 +10,7 @@ hide: [navigation]
 
 ## Context
 
-Iolanta currently has a visualization index YAML-LD file, but that index is centralized, wired into the codebase, and not usable by other publishers. Ontology publishers should be able to publish accompanying visualization information for an ontology, such as multilingual labels and VANN term groups, so Iolanta can discover and use it. The immediate target is ontology visualization data such as IBIS, while the mechanism should leave room for other resource types later.
+Iolanta used to load ontology visualization metadata from a bundled YAML-LD index wired into the codebase. That index was centralized and not usable by other publishers. Ontology publishers should be able to publish accompanying visualization information for an ontology, such as multilingual labels and VANN term groups, so Iolanta can discover and use it. The immediate target is ontology visualization data such as IBIS, while the mechanism should leave room for other resource types later.
 
 The solution needs to:
 
@@ -31,7 +31,7 @@ Use nanopublications as the primary public publication and discovery mechanism f
 | Status | Item | Discovery | Description |
 |--------|------|-----------|-------------|
 | ✅ | [Nanopublications](https://nanopub.net/docs/architecture/) | ✅ Public query/discovery network | Publish visualization assertions as provenance-carrying RDF publications that can be queried and cited independently of the ontology host. This covers RDF, RDFS, OWL, and other vocabularies whose canonical documents Iolanta cannot change. |
-| ✅ | Iolanta package or plugin metadata | ✅ Local installed discovery | Let installable Iolanta extensions ship visualization overlays for vocabularies they support, and keep bundled overlays as an offline fallback. |
+| ✅ | Iolanta package or plugin metadata | ✅ Local installed discovery | Let installable Iolanta extensions ship visualization overlays for vocabularies they support. Bundled files under `docs/visualizations/` remain authoring sources published to `https://iolanta.tech/visualizations/` but are not loaded at runtime. |
 | ✅ | Publisher-controlled ontology RDF links to visualization RDF | ⚠️ Only from cooperative ontology documents | Accept as an optional discovery input when the ontology publisher controls the ontology document. This cannot cover RDF, RDFS, OWL, or other vocabularies whose canonical documents Iolanta cannot change, so it cannot be the primary mechanism. |
 | ✅ | Publisher-controlled HTTP `Link` headers with `describedby` | ⚠️ Only from cooperative ontology origins | Accept as an optional discovery input when the ontology publisher controls the HTTP response and can advertise visualization metadata with the [`describedby`](https://www.iana.org/assignments/link-relations) relation. This cannot cover vocabularies whose origin Iolanta does not control. |
 | ❌ | [DCAT](https://www.w3.org/TR/vocab-dcat/) or [VoID](https://www.w3.org/2001/sw/interest/void/) catalog as a selected mechanism | ⚠️ Needs catalog discovery | Useful as metadata inside or around nanopublications, but not sufficient as a selected mechanism without also choosing which catalog Iolanta should query. |
@@ -39,20 +39,20 @@ Use nanopublications as the primary public publication and discovery mechanism f
 | ❌ | [IPFS](https://docs.ipfs.tech/how-to/content-addressing-data-sets/) or IPLD as a selected mechanism | ❌ No discovery by itself | Useful for immutable visualization snapshots referenced from nanopublications, catalogs, publisher links, or plugin metadata, but content addressing does not solve discovery by itself. |
 | ❌ | Well-known visualization index on the ontology origin | ❌ No discovery for uncontrolled origins | Define an Iolanta-specific [well-known URI](https://www.rfc-editor.org/rfc/rfc8615.html), but this still requires control over the ontology origin, so it does not work for RDF, RDFS, OWL, or other canonical vocabularies Iolanta cannot ask to change. |
 | ❌ | [LDP](https://www.w3.org/TR/ldp/) or [Solid Type Index](https://solid.github.io/type-indexes/) registry | ⚠️ Needs registry discovery | This gives an enumerable container, but Iolanta would still need to know which registry to ask, and it adds a server or account model that is heavier than publishing nanopublications. |
-| ❌ | Built-in centralized Iolanta visualization index as the primary mechanism | ✅ Iolanta-controlled discovery only | This is the current implementation, but it requires Iolanta source changes and does not let other publishers participate directly. |
+| ❌ | Built-in centralized Iolanta visualization index as the primary mechanism | ✅ Iolanta-controlled discovery only | This was the previous runtime implementation. It required Iolanta source changes and did not let other publishers participate directly. Runtime discovery now queries the public nanopub registry instead. |
 
 Each selected publication mechanism must include RDF that links the visualization data back to the ontology it describes, so Iolanta can query by ontology IRI after the publication mechanism has exposed or indexed the RDF.
 
 ## Consequences
 
-- Iolanta will need a discovery layer that can gather visualization candidates from more than one mechanism and load all accepted RDF graphs.
-- The current bundled visualization index can remain as a compatibility fallback, but not as the only publication path.
+- Iolanta needs a discovery layer that can gather visualization candidates from more than one mechanism and load all accepted RDF graphs.
+- Files under `docs/visualizations/` remain authoring sources and MkDocs static assets; they are not loaded at runtime. Runtime discovery uses signed visualization nanopublications from the public registry (see [`iolanta:visualizes`](/visualizes/)).
 - Discovery and trust policy need to be separate: finding a visualization graph does not imply that Iolanta should prefer it over publisher-controlled, user-configured, or locally installed data.
 
 #### Implementation Steps
 
-- [ ] Define the minimum RDF shape for a visualization document that describes an ontology.
-- [ ] Replace the hardcoded visualization index load with a visualization discovery service.
-- [ ] Teach the ontology facet to use discovered visualization graphs before rendering term groups and labels.
-- [ ] Keep the bundled index as a fallback source while external publication mechanisms are introduced.
-- [ ] Add regression tests using IBIS-like ontology data and an externally published visualization graph.
+- [x] Define the minimum RDF shape for a visualization document that describes an ontology — documented on [`iolanta:visualizes`](/visualizes/).
+- [x] Replace the hardcoded visualization index load with a visualization discovery service — [`iolanta/discovery/visualization_nanopublications.py`](https://github.com/iolanta-tech/iolanta/blob/master/iolanta/discovery/visualization_nanopublications.py) queries the Knowledge Pixels registry on the first `Iolanta.render()` per instance.
+- [x] Teach the ontology facet to use discovered visualization graphs before rendering term groups and labels — assertion graphs from active visualization nanopubs are loaded into the local dataset; [`MkDocsOntologyFacet`](/Facet/) and [`OntologyFacet`](/Facet/) pick up `vann:termGroup` via the existing ontology SPARQL.
+- [x] Keep bundled overlays as authoring sources while external publication mechanisms are introduced — `docs/visualizations/` is published to `https://iolanta.tech/visualizations/` but not read at runtime.
+- [x] Add regression tests using IBIS-like ontology data and an externally published visualization graph — see `tests/discovery/`.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -61,3 +61,7 @@ project data, installed Iolanta facilities, and normal web loading.
 
 See [`--render-template` macros & variables](/reference/render-template-macros-and-variables/)
 for the supported template surface.
+
+## Visualization discovery
+
+Pass `--without-visualization-cache-index` to refresh the visualization nanopub URL list from the [Knowledge Pixels](https://query.knowledgepixels.com/) registry on every run while still updating the disk cache. See [`iolanta:visualizes`](/visualizes/) for the full discovery flow.

--- a/docs/reference/rdf.md
+++ b/docs/reference/rdf.md
@@ -5,6 +5,6 @@ hide: [toc]
 
 # RDF vocabulary
 
-The [RDF](https://www.w3.org/TR/rdf11-mt/) vocabulary (namespace `http://www.w3.org/1999/02/22-rdf-syntax-ns#`), rendered by Iolanta.
+The [RDF](https://www.w3.org/TR/rdf11-mt/) vocabulary (namespace `http://www.w3.org/1999/02/22-rdf-syntax-ns#`), rendered by Iolanta. Term groups come from visualization [nanopublications](/visualizes/) discovered at render time; see the [`iolanta:visualizes`](/visualizes/) example for the current RDF grouping.
 
 {{ URIRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#") | as('mkdocs-material') }}

--- a/docs/reference/rdfs.md
+++ b/docs/reference/rdfs.md
@@ -5,6 +5,6 @@ hide: [toc]
 
 # RDF Schema
 
-The [RDF Schema](http://www.w3.org/2000/01/rdf-schema#) (RDFS) vocabulary, rendered by Iolanta from the bundled `docs/visualizations/rdfs.yaml` overlay.
+The [RDF Schema](http://www.w3.org/2000/01/rdf-schema#) (RDFS) vocabulary, rendered by Iolanta. Term groups appear when a signed visualization [nanopublication](/visualizes/) whose provenance contains `iolanta:visualizes <http://www.w3.org/2000/01/rdf-schema#>` is loaded at render time. The overlay authoring source is [`docs/visualizations/rdfs.yaml`](https://github.com/iolanta-tech/iolanta/blob/master/docs/visualizations/rdfs.yaml), published at [`https://iolanta.tech/visualizations/rdfs.yaml`](https://iolanta.tech/visualizations/rdfs.yaml).
 
 {{ URIRef("http://www.w3.org/2000/01/rdf-schema#") | as('mkdocs-material') }}

--- a/docs/visualizes.md
+++ b/docs/visualizes.md
@@ -32,7 +32,7 @@ Iolanta uses `iolanta:visualizes` at render time to discover community-published
 
 ## Discovery flow
 
-On the first [`Iolanta.render()`](/reference/iolanta/) call for each `Iolanta` instance, Iolanta queries the public [Knowledge Pixels](https://query.knowledgepixels.com/) nanopub registry for all signed, non-invalidated, non-superseded visualization nanopublications, loads their assertion graphs into the local dataset, and caches the resulting nanopub URL list for one day on disk ([cashews](https://pypi.org/project/cashews/) `@cache.soft` under `~/.cache/iolanta/visualization-index/`). Later renders on the same instance reuse the loaded graphs; nanopub documents are HTTP-cached separately by `yaml-ld` via `requests-cache`. If a registry refresh fails, Iolanta falls back to stale cached URLs when available; otherwise it logs a warning and continues without remote visualizations. Pass `--without-visualization-cache-index` to the CLI to always refresh the URL list from the registry while still updating the disk cache. The grouping triples (`vann:termGroup`, `rdfs:label`) then become visible to the regular ontology-rendering SPARQL used by [`MkDocsOntologyFacet`](/Facet/) and [`OntologyFacet`](/Facet/).
+On the first [`Iolanta.render()`](https://github.com/iolanta-tech/iolanta/blob/master/iolanta/iolanta.py) call for each `Iolanta` instance, Iolanta queries the public [Knowledge Pixels](https://query.knowledgepixels.com/) nanopub registry for all signed, non-invalidated, non-superseded visualization nanopublications, loads their assertion graphs into the local dataset, and caches the resulting nanopub URL list for one day on disk ([cashews](https://pypi.org/project/cashews/) `@cache.soft` under `~/.cache/iolanta/visualization-index/`). Later renders on the same instance reuse the loaded graphs; nanopub documents are HTTP-cached separately by `yaml-ld` via `requests-cache`. If a registry refresh fails, Iolanta falls back to stale cached URLs when available; otherwise it logs a warning and continues without remote visualizations. Pass `--without-visualization-cache-index` to the CLI to always refresh the URL list from the registry while still updating the disk cache. The grouping triples (`vann:termGroup`, `rdfs:label`) then become visible to the regular ontology-rendering SPARQL used by [`MkDocsOntologyFacet`](/Facet/) and [`OntologyFacet`](/Facet/).
 
 ```sparql
 PREFIX dcterms: <http://purl.org/dc/terms/>
@@ -73,6 +73,14 @@ ORDER BY DESC(?created)
 Iolanta loads **all** active matches from this index, not only the latest nanopublication per ontology. If multiple signed nanopublications visualize the same ontology, their assertion graphs are all loaded.
 
 The discovery code lives in [`iolanta/discovery/visualization_nanopublications.py`](https://github.com/iolanta-tech/iolanta/blob/master/iolanta/discovery/visualization_nanopublications.py).
+
+## Authoring overlays
+
+Files under [`docs/visualizations/`](https://github.com/iolanta-tech/iolanta/tree/master/docs/visualizations) are published to [`https://iolanta.tech/visualizations/`](https://iolanta.tech/visualizations/) as static MkDocs assets. Iolanta does **not** load them at runtime. To make an overlay discoverable, sign a visualization [nanopublication](/blog/2025-01-21-nanopublications/) whose provenance contains `iolanta:visualizes` pointing at the target ontology.
+
+## Cache control
+
+The registry URL list is cached for one day under `~/.cache/iolanta/visualization-index/`. Delete that directory to force a cold start on the next render. Pass `--without-visualization-cache-index` to the [`iolanta` CLI](/reference/cli/) to skip reading the disk cache on a given run while still writing a fresh result.
 
 ## Example
 


### PR DESCRIPTION
## Summary
- Align the visualization discovery ADR with the implemented nanopub registry flow
- Document `--without-visualization-cache-index`, authoring overlays, and cache control
- Fix RDF/RDFS reference pages that still described bundled runtime overlays

## Test plan
- [x] Docs-only change; no code or tests affected
- [ ] Verify MkDocs pages render on CI